### PR TITLE
Added CI Deployment with TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
   - "stable"
-script:
+before_script:
   - npm run convert-markdown -- --all

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ before_script:
 deploy:
   provider: pages
   skip_cleanup: true
-  file: guides/*
-  local_dir: guides
+  file: ./*
+  local_dir: .
   github_token: $GITHUB_TOKEN # Set in travis-ci.org dashboard
   target_branch: gh-pages
   on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,4 @@ deploy:
   provider: pages
   skip_cleanup: true
   github_token: $GITHUB_TOKEN # Set in travis-ci.org dashboard
+  target_branch: gh-pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ deploy:
   file_glob: true
   skip_cleanup: true
   file: guides/*
+  target_branch: gh-pages
   on:
     repo: Bucko13/bcoin-org.github.io
     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,12 @@ before_script:
 - npm run clear-guides
 - npm run convert-markdown -- --all
 deploy:
-  provider: releases
-  api_key:
-    secure: Um9qSOuCkWooIF2WkSiTS3oqsfkKWH3ZsSjTjHF9rtarmZML2HYpHwIVvK6BXqyWveTyF3P35AxRJucw+V+EHYg8gPaLNFnmSN/+74hO9n53lueDkf4Dl9EI8xSWBSRp+gaZcooDHk7L1F+k/eRyZKhe6OsH3KniHCF4OY1EkCHM32bxi4yvXWSS3xuWfbk+sA3jJAXPYhsD8vP3N8xYTnLaT5UveSVAApKot+Yp1lY+uL8G3gzmxwhuVMOkcUwnq0q2hoI8yDQTca0kY04Mee/h8nPCh9Q07sPTW2fXWEJ5IQYkefZ7xXS73L8dhFqErv9I9gFhoGos1Qng/XkLmS3Ie1/GZFABw9UTITUHcQYQzGwfUufgixbS7v5+mQxq7hKCaQA++zReJNxIMWnPeKpGDoFkJcPev9viLbVnZ5ZOjwv+qo9B/nOhfQvZkEMbLrzozZcQzAo82RQUpLP/Pe3cBMC7X/hQRrh7Udw7LiPRPOiLBxgjgxzlR68IAA4fCKoGrj2tCuHN2f0qKfRUdyi5vnlj8f6Ul/QTLCDDe9t17QNxTjaiviAd373RjTRpnq4U9wpJMCQItDX30cwgBHxnQmg2z7FJpkTsz4pJc5O+RqlmcJQmV9JOA+vD6MfzUsiHMo+d9ulSI5d/v5HvBNhEGLu3eFyvx8d/tofjNuo=
-  file_glob: true
+  provider: pages
   skip_cleanup: true
   file: guides/*
+  local_dir: guides
   target_branch: gh-pages
   on:
+    all_branches: true
     repo: Bucko13/bcoin-org.github.io
     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ deploy:
   target_branch: gh-pages
   on:
     branch: master
-    repo: Bucko13/bcoin-org.github.io
+    repo: bcoin-org/bcoin-org.github.io

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,5 @@ deploy:
   github_token: $GITHUB_TOKEN # Set in travis-ci.org dashboard
   target_branch: gh-pages
   on:
-    all_branches: true
+    branch: master
     repo: Bucko13/bcoin-org.github.io

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,3 @@ deploy:
   on:
     all_branches: true
     repo: Bucko13/bcoin-org.github.io
-    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ deploy:
   provider: pages
   skip_cleanup: true
   github_token: $GITHUB_TOKEN # Set in travis-ci.org dashboard
-  target_branch: gh-pages
+  target_branch: travis-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ deploy:
   skip_cleanup: true
   file: guides/*
   local_dir: guides
+  github_token: $GITHUB_TOKEN # Set in travis-ci.org dashboard
   target_branch: gh-pages
   on:
     all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: node_js
+node_js:
+  - "stable"
+script:
+  - npm run convert-markdown -- --all
+branches:
+  only:
+    - master 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,7 @@ node_js:
 before_script:
   - npm run clear-guides
   - npm run convert-markdown -- --all
+deploy:
+  provider: pages
+  skip_cleanup: true
+  github_token: $GITHUB_TOKEN # Set in travis-ci.org dashboard

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,3 @@ node_js:
   - "stable"
 script:
   - npm run convert-markdown -- --all
-branches:
-  only:
-    - master 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,16 @@
 language: node_js
 node_js:
-  - "stable"
+- stable
 before_script:
-  - npm run clear-guides
-  - npm run convert-markdown -- --all
+- npm run clear-guides
+- npm run convert-markdown -- --all
 deploy:
-  provider: pages
+  provider: releases
+  api_key:
+    secure: Um9qSOuCkWooIF2WkSiTS3oqsfkKWH3ZsSjTjHF9rtarmZML2HYpHwIVvK6BXqyWveTyF3P35AxRJucw+V+EHYg8gPaLNFnmSN/+74hO9n53lueDkf4Dl9EI8xSWBSRp+gaZcooDHk7L1F+k/eRyZKhe6OsH3KniHCF4OY1EkCHM32bxi4yvXWSS3xuWfbk+sA3jJAXPYhsD8vP3N8xYTnLaT5UveSVAApKot+Yp1lY+uL8G3gzmxwhuVMOkcUwnq0q2hoI8yDQTca0kY04Mee/h8nPCh9Q07sPTW2fXWEJ5IQYkefZ7xXS73L8dhFqErv9I9gFhoGos1Qng/XkLmS3Ie1/GZFABw9UTITUHcQYQzGwfUufgixbS7v5+mQxq7hKCaQA++zReJNxIMWnPeKpGDoFkJcPev9viLbVnZ5ZOjwv+qo9B/nOhfQvZkEMbLrzozZcQzAo82RQUpLP/Pe3cBMC7X/hQRrh7Udw7LiPRPOiLBxgjgxzlR68IAA4fCKoGrj2tCuHN2f0qKfRUdyi5vnlj8f6Ul/QTLCDDe9t17QNxTjaiviAd373RjTRpnq4U9wpJMCQItDX30cwgBHxnQmg2z7FJpkTsz4pJc5O+RqlmcJQmV9JOA+vD6MfzUsiHMo+d9ulSI5d/v5HvBNhEGLu3eFyvx8d/tofjNuo=
+  file_glob: true
   skip_cleanup: true
-  github_token: $GITHUB_TOKEN # Set in travis-ci.org dashboard
-  target_branch: travis-ci
+  file: guides/*
+  on:
+    repo: Bucko13/bcoin-org.github.io
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ language: node_js
 node_js:
   - "stable"
 before_script:
+  - npm run clear-guides
   - npm run convert-markdown -- --all

--- a/guides-markdown/guides-template.txt
+++ b/guides-markdown/guides-template.txt
@@ -192,7 +192,7 @@
 					<ul class="inner-nav pull-right">
 
 						<!-- HOME -->
-						<li><a href="../index.html">Bcoin Home</a></li>
+						<li><a href="../index.html">Homepage</a></li>
 						<!-- END HOME -->
 
 						<!-- FEATURES -->

--- a/guides-markdown/guides-template.txt
+++ b/guides-markdown/guides-template.txt
@@ -192,7 +192,7 @@
 					<ul class="inner-nav pull-right">
 
 						<!-- HOME -->
-						<li><a href="../index.html">Home</a></li>
+						<li><a href="../index.html">Bcoin Homepage</a></li>
 						<!-- END HOME -->
 
 						<!-- FEATURES -->

--- a/guides-markdown/guides-template.txt
+++ b/guides-markdown/guides-template.txt
@@ -192,7 +192,7 @@
 					<ul class="inner-nav pull-right">
 
 						<!-- HOME -->
-						<li><a href="../index.html">Bcoin Homepage</a></li>
+						<li><a href="../index.html">Home</a></li>
 						<!-- END HOME -->
 
 						<!-- FEATURES -->

--- a/guides-markdown/guides-template.txt
+++ b/guides-markdown/guides-template.txt
@@ -5,9 +5,9 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta name="description" content="">
 	<meta name="author" content="">
-	
+
 	<title>bcoin | Extending Bitcoin into Enterprise & Production</title>
-	
+
 	<!-- Favicons -->
 	<!-- old
 	<link rel="shortcut icon" href="../assets/images/bcoin-ico.png">-->
@@ -30,27 +30,27 @@
 	<meta name="msapplication-TileColor" content="#ffffff">
 	<meta name="msapplication-TileImage" content="../assets/images/ms-icon-144x144.png">
 	<meta name="theme-color" content="#ffffff">
-	
+
 	<!-- Web Fonts -->
 	<link href='http://fonts.googleapis.com/css?family=Open+Sans:300,400italic,400,600,700' rel='stylesheet'>
 	<link href='https://fonts.googleapis.com/css?family=Montserrat:700' rel='stylesheet' type='text/css'>
-	
+
 	<!-- Bootstrap core CSS -->
 	<link href="../assets/bootstrap/css/bootstrap.min.css" rel="stylesheet">
 
 	<!-- Code Snippet CSS -->
 	<link href="../assets/css/prism.css" rel="stylesheet">
-	
+
 	<!-- Icon Fonts -->
 	<link href="../assets/css/font-awesome.min.css" rel="stylesheet">
 	<link href="../assets/css/simple-line-icons.css" rel="stylesheet">
-	
+
 	<!-- Plugins -->
 	<link href="../assets/css/magnific-popup.css" rel="stylesheet">
 	<link href="../assets/css/owl.carousel.css" rel="stylesheet">
 	<link href="../assets/css/flexslider.css" rel="stylesheet">
 	<link href="../assets/css/animate.min.css" rel="stylesheet">
-	
+
 	<!-- Template core CSS -->
 	<link href="../assets/css/vertical.min.css" rel="stylesheet">
 	<link href="../assets/css/template.css" rel="stylesheet">
@@ -130,7 +130,7 @@
 						<img class="brand-dark" src="../assets/images/logo-dark.png" width="100" alt="">
 					</a>
 				</div>
-			
+
 				<!-- OPEN MOBILE MENU -->
 				<div class="main-nav-toggle">
 					<div class="nav-icon-toggle" data-toggle="collapse" data-target="#custom-collapse">
@@ -139,15 +139,15 @@
 						<span class="icon-bar"></span>
 					</div>
 				</div>
-			
+
 				<!-- WIDGETS MENU -->
 				<div class="inner-header pull-right hide-me">
 					<div class="menu-extras clearfix">
-			
+
 						<!-- SLACK LINK -->
 						<div class="menu-item">
 							<div class="">
-								<a href="../slack-signup.html" target="_blank" id="" data-toggle="tooltip" title="" data-placement="bottom" data-original-title="Join us on Slack!">								
+								<a href="../slack-signup.html" target="_blank" id="" data-toggle="tooltip" title="" data-placement="bottom" data-original-title="Join us on Slack!">
 									<img src="../assets/images/slack_icon.svg" width="18" height="18"/>
 									<span class=""></span>
 								</a>
@@ -157,7 +157,7 @@
 						<!-- STACK EXCHANGE LINK -->
 						<div class="menu-item">
 							<div class="">
-								<a href="https://bitcoin.stackexchange.com/questions/tagged/bcoin" target="_blank" id="" data-toggle="tooltip" title="" data-placement="bottom" data-original-title="Questions! Checkout Stack Exchange.">								
+								<a href="https://bitcoin.stackexchange.com/questions/tagged/bcoin" target="_blank" id="" data-toggle="tooltip" title="" data-placement="bottom" data-original-title="Questions! Checkout Stack Exchange.">
 									<img src="../assets/images/stack-exchange-icon.svg" width="18" height="18"/>
 									<span class=""></span>
 								</a>
@@ -166,7 +166,7 @@
 
 						<!-- GITHUB STUFF -->
 						<div class="menu-item">
-							<div class="">						
+							<div class="">
 								<a href="https://github.com/bcoin-org/bcoin" target="_blank" id="" data-toggle="tooltip" title="" data-placement="bottom" data-original-title="Visit bcoin on GitHub to see the code!">
 									<img src="../assets/images/github_icon.svg" width="18" height="18"/>
 									<span class=""></span>
@@ -174,25 +174,25 @@
                             </div>
 						</div>
 
-						<div class="menu-item">    
+						<div class="menu-item">
                             <div class="ghbuttons">
                                 <a class="github-button" href="https://github.com/bcoin-org/bcoin" data-icon="octicon-star" data-count-href="/bcoin-org/bcoin/stargazers" data-show-count="true" data-count-aria-label="# stargazers on GitHub" aria-label="Star bcoin-org/bcoin on GitHub">Star</a>
                                 <a class="github-button" href="https://github.com/bcoin-org/bcoin/fork" data-icon="octicon-repo-forked" data-count-href="/bcoin-org/bcoin/network" data-show-count="true" data-count-aria-label="# forks on GitHub" aria-label="Fork bcoin-org/bcoin on GitHub">Fork</a>
-                            </div>  
+                            </div>
                         </div>
-                        
-						
-	
-			
+
+
+
+
 					</div>
 				</div>
-			
+
 				<!-- MAIN MENU -->
 				<nav id="custom-collapse" class="main-nav collapse clearfix">
 					<ul class="inner-nav pull-right">
-			
+
 						<!-- HOME -->
-						<li><a href="../index.html">Home</a></li>
+						<li><a href="../index.html">Bcoin Home</a></li>
 						<!-- END HOME -->
 
 						<!-- FEATURES -->
@@ -200,25 +200,25 @@
 						<!-- END FEATURES -->
 
 						<!-- GUIDES -->
-						<li><a href="../guides.html">Guides</a></li>						
+						<li><a href="../guides.html">Guides</a></li>
 						<!-- GUIDES -->
 
-						<!-- API REFERENCE - newer, how to interact once you're setup 
+						<!-- API REFERENCE - newer, how to interact once you're setup
 						<li><a href="http://bcoin.io/docs/index.html">API Docs</a></li>-->
 						<!-- END API -->
 
 						<!-- FULL DOCS - older, full reference -->
 						<li><a href="http://bcoin.io/docs/index.html">Docs</a></li>
 						<!-- END DOCS -->
-			
-						<!-- DIVIDER 
+
+						<!-- DIVIDER
 						<li><a>&nbsp;</a></li>
-			
+
 						<li><a href="#">All Demos</a></li>-->
-			
+
 					</ul>
 				</nav>
-			
+
 			</div>
 		</header>
 	<!-- END HEADER -->
@@ -259,7 +259,7 @@
 								<li><a href="install-windows.html">Install on Windows</a></li>
 								<!--<li><a data-toggle="" href="">Quick Sync (Torrent) </a></li>-->
 							</ul>
-							<!-- guides added soon 
+							<!-- guides added soon
 							<br>
 							<h6 class="montserrat text-uppercase bottom-line">Guides</h6>
 							<ul class="icons-list">
@@ -311,7 +311,7 @@
 						</div>
 					</article>
 					<!-- END OF ARTICLE CONTAINER -->
-					
+
 					</div>
 					<!-- END BLOG CONTENT -->
 
@@ -329,7 +329,7 @@
 		</section>
 		<!-- END BLOGS -->
 
-		
+
 		<!-- PARALLAX DOCS CTA -->
 		<section class="module bg-white-alfa-30 parallax color-white" data-background="../assets/images/bg-header.jpg">
 			<div class="container">
@@ -366,16 +366,16 @@
 					<div class="col-sm-12 text-center m-b-35">
 						<img class="m-b-35 QR-code" src="../assets/images/donation_QR.png"/>
 						<p class="m-0"><strong>Bcoin Development Donation Address:</strong><br />3Bi9H1hzCHWJoFEjc4xzVzEMywi35dyvsV</p>
-						
+
 					</div>
 				</div>
 				<div class="row">
 					<div class="col-sm-12 text-center">
 						<p class="m-0">Copyright <a href="#">bcoin.io, Purse</a>, 2017, All Rights Reserved.</p>
-                        
+
 					</div>
 				</div>
-			
+
 			</div>
 		</footer>
 		<!-- END FOOTER -->
@@ -390,11 +390,11 @@
 	<script src="../assets/bootstrap/js/bootstrap.min.js"></script>
 	<script src="../assets/js/plugins.min.js"></script>
 	<script src="../assets/js/custom.min.js"></script>
-	
-	<script async defer src="../assets/js/prism.js"></script>	
-  
+
+	<script async defer src="../assets/js/prism.js"></script>
+
   <!-- github button js -->
-  <script async defer src="https://buttons.github.io/buttons.js"></script>	
-	
+  <script async defer src="https://buttons.github.io/buttons.js"></script>
+
 </body>
 </html>

--- a/guides-markdown/guides-template.txt
+++ b/guides-markdown/guides-template.txt
@@ -192,7 +192,7 @@
 					<ul class="inner-nav pull-right">
 
 						<!-- HOME -->
-						<li><a href="../index.html">Home</a></li>
+						<li><a href="../index.html">Homepage</a></li>
 						<!-- END HOME -->
 
 						<!-- FEATURES -->

--- a/guides-markdown/guides-template.txt
+++ b/guides-markdown/guides-template.txt
@@ -192,7 +192,7 @@
 					<ul class="inner-nav pull-right">
 
 						<!-- HOME -->
-						<li><a href="../index.html">Homepage</a></li>
+						<li><a href="../index.html">Home</a></li>
 						<!-- END HOME -->
 
 						<!-- FEATURES -->

--- a/guides/install-linux.html
+++ b/guides/install-linux.html
@@ -5,9 +5,9 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta name="description" content="">
 	<meta name="author" content="">
-	
+
 	<title>bcoin | Extending Bitcoin into Enterprise & Production</title>
-	
+
 	<!-- Favicons -->
 	<!-- old
 	<link rel="shortcut icon" href="../assets/images/bcoin-ico.png">-->
@@ -30,27 +30,27 @@
 	<meta name="msapplication-TileColor" content="#ffffff">
 	<meta name="msapplication-TileImage" content="../assets/images/ms-icon-144x144.png">
 	<meta name="theme-color" content="#ffffff">
-	
+
 	<!-- Web Fonts -->
 	<link href='http://fonts.googleapis.com/css?family=Open+Sans:300,400italic,400,600,700' rel='stylesheet'>
 	<link href='https://fonts.googleapis.com/css?family=Montserrat:700' rel='stylesheet' type='text/css'>
-	
+
 	<!-- Bootstrap core CSS -->
 	<link href="../assets/bootstrap/css/bootstrap.min.css" rel="stylesheet">
 
 	<!-- Code Snippet CSS -->
 	<link href="../assets/css/prism.css" rel="stylesheet">
-	
+
 	<!-- Icon Fonts -->
 	<link href="../assets/css/font-awesome.min.css" rel="stylesheet">
 	<link href="../assets/css/simple-line-icons.css" rel="stylesheet">
-	
+
 	<!-- Plugins -->
 	<link href="../assets/css/magnific-popup.css" rel="stylesheet">
 	<link href="../assets/css/owl.carousel.css" rel="stylesheet">
 	<link href="../assets/css/flexslider.css" rel="stylesheet">
 	<link href="../assets/css/animate.min.css" rel="stylesheet">
-	
+
 	<!-- Template core CSS -->
 	<link href="../assets/css/vertical.min.css" rel="stylesheet">
 	<link href="../assets/css/template.css" rel="stylesheet">
@@ -130,7 +130,7 @@
 						<img class="brand-dark" src="../assets/images/logo-dark.png" width="100" alt="">
 					</a>
 				</div>
-			
+
 				<!-- OPEN MOBILE MENU -->
 				<div class="main-nav-toggle">
 					<div class="nav-icon-toggle" data-toggle="collapse" data-target="#custom-collapse">
@@ -139,15 +139,15 @@
 						<span class="icon-bar"></span>
 					</div>
 				</div>
-			
+
 				<!-- WIDGETS MENU -->
 				<div class="inner-header pull-right hide-me">
 					<div class="menu-extras clearfix">
-			
+
 						<!-- SLACK LINK -->
 						<div class="menu-item">
 							<div class="">
-								<a href="../slack-signup.html" target="_blank" id="" data-toggle="tooltip" title="" data-placement="bottom" data-original-title="Join us on Slack!">								
+								<a href="../slack-signup.html" target="_blank" id="" data-toggle="tooltip" title="" data-placement="bottom" data-original-title="Join us on Slack!">
 									<img src="../assets/images/slack_icon.svg" width="18" height="18"/>
 									<span class=""></span>
 								</a>
@@ -157,7 +157,7 @@
 						<!-- STACK EXCHANGE LINK -->
 						<div class="menu-item">
 							<div class="">
-								<a href="https://bitcoin.stackexchange.com/questions/tagged/bcoin" target="_blank" id="" data-toggle="tooltip" title="" data-placement="bottom" data-original-title="Questions! Checkout Stack Exchange.">								
+								<a href="https://bitcoin.stackexchange.com/questions/tagged/bcoin" target="_blank" id="" data-toggle="tooltip" title="" data-placement="bottom" data-original-title="Questions! Checkout Stack Exchange.">
 									<img src="../assets/images/stack-exchange-icon.svg" width="18" height="18"/>
 									<span class=""></span>
 								</a>
@@ -166,7 +166,7 @@
 
 						<!-- GITHUB STUFF -->
 						<div class="menu-item">
-							<div class="">						
+							<div class="">
 								<a href="https://github.com/bcoin-org/bcoin" target="_blank" id="" data-toggle="tooltip" title="" data-placement="bottom" data-original-title="Visit bcoin on GitHub to see the code!">
 									<img src="../assets/images/github_icon.svg" width="18" height="18"/>
 									<span class=""></span>
@@ -174,25 +174,25 @@
                             </div>
 						</div>
 
-						<div class="menu-item">    
+						<div class="menu-item">
                             <div class="ghbuttons">
                                 <a class="github-button" href="https://github.com/bcoin-org/bcoin" data-icon="octicon-star" data-count-href="/bcoin-org/bcoin/stargazers" data-show-count="true" data-count-aria-label="# stargazers on GitHub" aria-label="Star bcoin-org/bcoin on GitHub">Star</a>
                                 <a class="github-button" href="https://github.com/bcoin-org/bcoin/fork" data-icon="octicon-repo-forked" data-count-href="/bcoin-org/bcoin/network" data-show-count="true" data-count-aria-label="# forks on GitHub" aria-label="Fork bcoin-org/bcoin on GitHub">Fork</a>
-                            </div>  
+                            </div>
                         </div>
-                        
-						
-	
-			
+
+
+
+
 					</div>
 				</div>
-			
+
 				<!-- MAIN MENU -->
 				<nav id="custom-collapse" class="main-nav collapse clearfix">
 					<ul class="inner-nav pull-right">
-			
+
 						<!-- HOME -->
-						<li><a href="../index.html">Home</a></li>
+						<li><a href="../index.html">Bcoin Home</a></li>
 						<!-- END HOME -->
 
 						<!-- FEATURES -->
@@ -200,25 +200,25 @@
 						<!-- END FEATURES -->
 
 						<!-- GUIDES -->
-						<li><a href="../guides.html">Guides</a></li>						
+						<li><a href="../guides.html">Guides</a></li>
 						<!-- GUIDES -->
 
-						<!-- API REFERENCE - newer, how to interact once you're setup 
+						<!-- API REFERENCE - newer, how to interact once you're setup
 						<li><a href="http://bcoin.io/docs/index.html">API Docs</a></li>-->
 						<!-- END API -->
 
 						<!-- FULL DOCS - older, full reference -->
 						<li><a href="http://bcoin.io/docs/index.html">Docs</a></li>
 						<!-- END DOCS -->
-			
-						<!-- DIVIDER 
+
+						<!-- DIVIDER
 						<li><a>&nbsp;</a></li>
-			
+
 						<li><a href="#">All Demos</a></li>-->
-			
+
 					</ul>
 				</nav>
-			
+
 			</div>
 		</header>
 	<!-- END HEADER -->
@@ -259,7 +259,7 @@
 								<li><a href="install-windows.html">Install on Windows</a></li>
 								<!--<li><a data-toggle="" href="">Quick Sync (Torrent) </a></li>-->
 							</ul>
-							<!-- guides added soon 
+							<!-- guides added soon
 							<br>
 							<h6 class="montserrat text-uppercase bottom-line">Guides</h6>
 							<ul class="icons-list">
@@ -322,7 +322,7 @@ bin/bcoin  <span class="token comment" spellcheck="true">#run</span></code></pre
 						</div>
 					</article>
 					<!-- END OF ARTICLE CONTAINER -->
-					
+
 					</div>
 					<!-- END BLOG CONTENT -->
 
@@ -340,7 +340,7 @@ bin/bcoin  <span class="token comment" spellcheck="true">#run</span></code></pre
 		</section>
 		<!-- END BLOGS -->
 
-		
+
 		<!-- PARALLAX DOCS CTA -->
 		<section class="module bg-white-alfa-30 parallax color-white" data-background="../assets/images/bg-header.jpg">
 			<div class="container">
@@ -377,16 +377,16 @@ bin/bcoin  <span class="token comment" spellcheck="true">#run</span></code></pre
 					<div class="col-sm-12 text-center m-b-35">
 						<img class="m-b-35 QR-code" src="../assets/images/donation_QR.png"/>
 						<p class="m-0"><strong>Bcoin Development Donation Address:</strong><br />3Bi9H1hzCHWJoFEjc4xzVzEMywi35dyvsV</p>
-						
+
 					</div>
 				</div>
 				<div class="row">
 					<div class="col-sm-12 text-center">
 						<p class="m-0">Copyright <a href="#">bcoin.io, Purse</a>, 2017, All Rights Reserved.</p>
-                        
+
 					</div>
 				</div>
-			
+
 			</div>
 		</footer>
 		<!-- END FOOTER -->
@@ -401,11 +401,11 @@ bin/bcoin  <span class="token comment" spellcheck="true">#run</span></code></pre
 	<script src="../assets/bootstrap/js/bootstrap.min.js"></script>
 	<script src="../assets/js/plugins.min.js"></script>
 	<script src="../assets/js/custom.min.js"></script>
-	
-	<script async defer src="../assets/js/prism.js"></script>	
-  
+
+	<script async defer src="../assets/js/prism.js"></script>
+
   <!-- github button js -->
-  <script async defer src="https://buttons.github.io/buttons.js"></script>	
-	
+  <script async defer src="https://buttons.github.io/buttons.js"></script>
+
 </body>
 </html>

--- a/guides/install-mac.html
+++ b/guides/install-mac.html
@@ -5,9 +5,9 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta name="description" content="">
 	<meta name="author" content="">
-	
+
 	<title>bcoin | Extending Bitcoin into Enterprise & Production</title>
-	
+
 	<!-- Favicons -->
 	<!-- old
 	<link rel="shortcut icon" href="../assets/images/bcoin-ico.png">-->
@@ -30,27 +30,27 @@
 	<meta name="msapplication-TileColor" content="#ffffff">
 	<meta name="msapplication-TileImage" content="../assets/images/ms-icon-144x144.png">
 	<meta name="theme-color" content="#ffffff">
-	
+
 	<!-- Web Fonts -->
 	<link href='http://fonts.googleapis.com/css?family=Open+Sans:300,400italic,400,600,700' rel='stylesheet'>
 	<link href='https://fonts.googleapis.com/css?family=Montserrat:700' rel='stylesheet' type='text/css'>
-	
+
 	<!-- Bootstrap core CSS -->
 	<link href="../assets/bootstrap/css/bootstrap.min.css" rel="stylesheet">
 
 	<!-- Code Snippet CSS -->
 	<link href="../assets/css/prism.css" rel="stylesheet">
-	
+
 	<!-- Icon Fonts -->
 	<link href="../assets/css/font-awesome.min.css" rel="stylesheet">
 	<link href="../assets/css/simple-line-icons.css" rel="stylesheet">
-	
+
 	<!-- Plugins -->
 	<link href="../assets/css/magnific-popup.css" rel="stylesheet">
 	<link href="../assets/css/owl.carousel.css" rel="stylesheet">
 	<link href="../assets/css/flexslider.css" rel="stylesheet">
 	<link href="../assets/css/animate.min.css" rel="stylesheet">
-	
+
 	<!-- Template core CSS -->
 	<link href="../assets/css/vertical.min.css" rel="stylesheet">
 	<link href="../assets/css/template.css" rel="stylesheet">
@@ -130,7 +130,7 @@
 						<img class="brand-dark" src="../assets/images/logo-dark.png" width="100" alt="">
 					</a>
 				</div>
-			
+
 				<!-- OPEN MOBILE MENU -->
 				<div class="main-nav-toggle">
 					<div class="nav-icon-toggle" data-toggle="collapse" data-target="#custom-collapse">
@@ -139,15 +139,15 @@
 						<span class="icon-bar"></span>
 					</div>
 				</div>
-			
+
 				<!-- WIDGETS MENU -->
 				<div class="inner-header pull-right hide-me">
 					<div class="menu-extras clearfix">
-			
+
 						<!-- SLACK LINK -->
 						<div class="menu-item">
 							<div class="">
-								<a href="../slack-signup.html" target="_blank" id="" data-toggle="tooltip" title="" data-placement="bottom" data-original-title="Join us on Slack!">								
+								<a href="../slack-signup.html" target="_blank" id="" data-toggle="tooltip" title="" data-placement="bottom" data-original-title="Join us on Slack!">
 									<img src="../assets/images/slack_icon.svg" width="18" height="18"/>
 									<span class=""></span>
 								</a>
@@ -157,7 +157,7 @@
 						<!-- STACK EXCHANGE LINK -->
 						<div class="menu-item">
 							<div class="">
-								<a href="https://bitcoin.stackexchange.com/questions/tagged/bcoin" target="_blank" id="" data-toggle="tooltip" title="" data-placement="bottom" data-original-title="Questions! Checkout Stack Exchange.">								
+								<a href="https://bitcoin.stackexchange.com/questions/tagged/bcoin" target="_blank" id="" data-toggle="tooltip" title="" data-placement="bottom" data-original-title="Questions! Checkout Stack Exchange.">
 									<img src="../assets/images/stack-exchange-icon.svg" width="18" height="18"/>
 									<span class=""></span>
 								</a>
@@ -166,7 +166,7 @@
 
 						<!-- GITHUB STUFF -->
 						<div class="menu-item">
-							<div class="">						
+							<div class="">
 								<a href="https://github.com/bcoin-org/bcoin" target="_blank" id="" data-toggle="tooltip" title="" data-placement="bottom" data-original-title="Visit bcoin on GitHub to see the code!">
 									<img src="../assets/images/github_icon.svg" width="18" height="18"/>
 									<span class=""></span>
@@ -174,25 +174,25 @@
                             </div>
 						</div>
 
-						<div class="menu-item">    
+						<div class="menu-item">
                             <div class="ghbuttons">
                                 <a class="github-button" href="https://github.com/bcoin-org/bcoin" data-icon="octicon-star" data-count-href="/bcoin-org/bcoin/stargazers" data-show-count="true" data-count-aria-label="# stargazers on GitHub" aria-label="Star bcoin-org/bcoin on GitHub">Star</a>
                                 <a class="github-button" href="https://github.com/bcoin-org/bcoin/fork" data-icon="octicon-repo-forked" data-count-href="/bcoin-org/bcoin/network" data-show-count="true" data-count-aria-label="# forks on GitHub" aria-label="Fork bcoin-org/bcoin on GitHub">Fork</a>
-                            </div>  
+                            </div>
                         </div>
-                        
-						
-	
-			
+
+
+
+
 					</div>
 				</div>
-			
+
 				<!-- MAIN MENU -->
 				<nav id="custom-collapse" class="main-nav collapse clearfix">
 					<ul class="inner-nav pull-right">
-			
+
 						<!-- HOME -->
-						<li><a href="../index.html">Home</a></li>
+						<li><a href="../index.html">Bcoin Home</a></li>
 						<!-- END HOME -->
 
 						<!-- FEATURES -->
@@ -200,25 +200,25 @@
 						<!-- END FEATURES -->
 
 						<!-- GUIDES -->
-						<li><a href="../guides.html">Guides</a></li>						
+						<li><a href="../guides.html">Guides</a></li>
 						<!-- GUIDES -->
 
-						<!-- API REFERENCE - newer, how to interact once you're setup 
+						<!-- API REFERENCE - newer, how to interact once you're setup
 						<li><a href="http://bcoin.io/docs/index.html">API Docs</a></li>-->
 						<!-- END API -->
 
 						<!-- FULL DOCS - older, full reference -->
 						<li><a href="http://bcoin.io/docs/index.html">Docs</a></li>
 						<!-- END DOCS -->
-			
-						<!-- DIVIDER 
+
+						<!-- DIVIDER
 						<li><a>&nbsp;</a></li>
-			
+
 						<li><a href="#">All Demos</a></li>-->
-			
+
 					</ul>
 				</nav>
-			
+
 			</div>
 		</header>
 	<!-- END HEADER -->
@@ -259,7 +259,7 @@
 								<li><a href="install-windows.html">Install on Windows</a></li>
 								<!--<li><a data-toggle="" href="">Quick Sync (Torrent) </a></li>-->
 							</ul>
-							<!-- guides added soon 
+							<!-- guides added soon
 							<br>
 							<h6 class="montserrat text-uppercase bottom-line">Guides</h6>
 							<ul class="icons-list">
@@ -320,7 +320,7 @@ bin/bcoin  <span class="token comment" spellcheck="true">#run</span></code></pre
 						</div>
 					</article>
 					<!-- END OF ARTICLE CONTAINER -->
-					
+
 					</div>
 					<!-- END BLOG CONTENT -->
 
@@ -338,7 +338,7 @@ bin/bcoin  <span class="token comment" spellcheck="true">#run</span></code></pre
 		</section>
 		<!-- END BLOGS -->
 
-		
+
 		<!-- PARALLAX DOCS CTA -->
 		<section class="module bg-white-alfa-30 parallax color-white" data-background="../assets/images/bg-header.jpg">
 			<div class="container">
@@ -375,16 +375,16 @@ bin/bcoin  <span class="token comment" spellcheck="true">#run</span></code></pre
 					<div class="col-sm-12 text-center m-b-35">
 						<img class="m-b-35 QR-code" src="../assets/images/donation_QR.png"/>
 						<p class="m-0"><strong>Bcoin Development Donation Address:</strong><br />3Bi9H1hzCHWJoFEjc4xzVzEMywi35dyvsV</p>
-						
+
 					</div>
 				</div>
 				<div class="row">
 					<div class="col-sm-12 text-center">
 						<p class="m-0">Copyright <a href="#">bcoin.io, Purse</a>, 2017, All Rights Reserved.</p>
-                        
+
 					</div>
 				</div>
-			
+
 			</div>
 		</footer>
 		<!-- END FOOTER -->
@@ -399,11 +399,11 @@ bin/bcoin  <span class="token comment" spellcheck="true">#run</span></code></pre
 	<script src="../assets/bootstrap/js/bootstrap.min.js"></script>
 	<script src="../assets/js/plugins.min.js"></script>
 	<script src="../assets/js/custom.min.js"></script>
-	
-	<script async defer src="../assets/js/prism.js"></script>	
-  
+
+	<script async defer src="../assets/js/prism.js"></script>
+
   <!-- github button js -->
-  <script async defer src="https://buttons.github.io/buttons.js"></script>	
-	
+  <script async defer src="https://buttons.github.io/buttons.js"></script>
+
 </body>
 </html>

--- a/guides/install-windows.html
+++ b/guides/install-windows.html
@@ -5,9 +5,9 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta name="description" content="">
 	<meta name="author" content="">
-	
+
 	<title>bcoin | Extending Bitcoin into Enterprise & Production</title>
-	
+
 	<!-- Favicons -->
 	<!-- old
 	<link rel="shortcut icon" href="../assets/images/bcoin-ico.png">-->
@@ -30,27 +30,27 @@
 	<meta name="msapplication-TileColor" content="#ffffff">
 	<meta name="msapplication-TileImage" content="../assets/images/ms-icon-144x144.png">
 	<meta name="theme-color" content="#ffffff">
-	
+
 	<!-- Web Fonts -->
 	<link href='http://fonts.googleapis.com/css?family=Open+Sans:300,400italic,400,600,700' rel='stylesheet'>
 	<link href='https://fonts.googleapis.com/css?family=Montserrat:700' rel='stylesheet' type='text/css'>
-	
+
 	<!-- Bootstrap core CSS -->
 	<link href="../assets/bootstrap/css/bootstrap.min.css" rel="stylesheet">
 
 	<!-- Code Snippet CSS -->
 	<link href="../assets/css/prism.css" rel="stylesheet">
-	
+
 	<!-- Icon Fonts -->
 	<link href="../assets/css/font-awesome.min.css" rel="stylesheet">
 	<link href="../assets/css/simple-line-icons.css" rel="stylesheet">
-	
+
 	<!-- Plugins -->
 	<link href="../assets/css/magnific-popup.css" rel="stylesheet">
 	<link href="../assets/css/owl.carousel.css" rel="stylesheet">
 	<link href="../assets/css/flexslider.css" rel="stylesheet">
 	<link href="../assets/css/animate.min.css" rel="stylesheet">
-	
+
 	<!-- Template core CSS -->
 	<link href="../assets/css/vertical.min.css" rel="stylesheet">
 	<link href="../assets/css/template.css" rel="stylesheet">
@@ -130,7 +130,7 @@
 						<img class="brand-dark" src="../assets/images/logo-dark.png" width="100" alt="">
 					</a>
 				</div>
-			
+
 				<!-- OPEN MOBILE MENU -->
 				<div class="main-nav-toggle">
 					<div class="nav-icon-toggle" data-toggle="collapse" data-target="#custom-collapse">
@@ -139,15 +139,15 @@
 						<span class="icon-bar"></span>
 					</div>
 				</div>
-			
+
 				<!-- WIDGETS MENU -->
 				<div class="inner-header pull-right hide-me">
 					<div class="menu-extras clearfix">
-			
+
 						<!-- SLACK LINK -->
 						<div class="menu-item">
 							<div class="">
-								<a href="../slack-signup.html" target="_blank" id="" data-toggle="tooltip" title="" data-placement="bottom" data-original-title="Join us on Slack!">								
+								<a href="../slack-signup.html" target="_blank" id="" data-toggle="tooltip" title="" data-placement="bottom" data-original-title="Join us on Slack!">
 									<img src="../assets/images/slack_icon.svg" width="18" height="18"/>
 									<span class=""></span>
 								</a>
@@ -157,7 +157,7 @@
 						<!-- STACK EXCHANGE LINK -->
 						<div class="menu-item">
 							<div class="">
-								<a href="https://bitcoin.stackexchange.com/questions/tagged/bcoin" target="_blank" id="" data-toggle="tooltip" title="" data-placement="bottom" data-original-title="Questions! Checkout Stack Exchange.">								
+								<a href="https://bitcoin.stackexchange.com/questions/tagged/bcoin" target="_blank" id="" data-toggle="tooltip" title="" data-placement="bottom" data-original-title="Questions! Checkout Stack Exchange.">
 									<img src="../assets/images/stack-exchange-icon.svg" width="18" height="18"/>
 									<span class=""></span>
 								</a>
@@ -166,7 +166,7 @@
 
 						<!-- GITHUB STUFF -->
 						<div class="menu-item">
-							<div class="">						
+							<div class="">
 								<a href="https://github.com/bcoin-org/bcoin" target="_blank" id="" data-toggle="tooltip" title="" data-placement="bottom" data-original-title="Visit bcoin on GitHub to see the code!">
 									<img src="../assets/images/github_icon.svg" width="18" height="18"/>
 									<span class=""></span>
@@ -174,25 +174,25 @@
                             </div>
 						</div>
 
-						<div class="menu-item">    
+						<div class="menu-item">
                             <div class="ghbuttons">
                                 <a class="github-button" href="https://github.com/bcoin-org/bcoin" data-icon="octicon-star" data-count-href="/bcoin-org/bcoin/stargazers" data-show-count="true" data-count-aria-label="# stargazers on GitHub" aria-label="Star bcoin-org/bcoin on GitHub">Star</a>
                                 <a class="github-button" href="https://github.com/bcoin-org/bcoin/fork" data-icon="octicon-repo-forked" data-count-href="/bcoin-org/bcoin/network" data-show-count="true" data-count-aria-label="# forks on GitHub" aria-label="Fork bcoin-org/bcoin on GitHub">Fork</a>
-                            </div>  
+                            </div>
                         </div>
-                        
-						
-	
-			
+
+
+
+
 					</div>
 				</div>
-			
+
 				<!-- MAIN MENU -->
 				<nav id="custom-collapse" class="main-nav collapse clearfix">
 					<ul class="inner-nav pull-right">
-			
+
 						<!-- HOME -->
-						<li><a href="../index.html">Home</a></li>
+						<li><a href="../index.html">Bcoin Home</a></li>
 						<!-- END HOME -->
 
 						<!-- FEATURES -->
@@ -200,25 +200,25 @@
 						<!-- END FEATURES -->
 
 						<!-- GUIDES -->
-						<li><a href="../guides.html">Guides</a></li>						
+						<li><a href="../guides.html">Guides</a></li>
 						<!-- GUIDES -->
 
-						<!-- API REFERENCE - newer, how to interact once you're setup 
+						<!-- API REFERENCE - newer, how to interact once you're setup
 						<li><a href="http://bcoin.io/docs/index.html">API Docs</a></li>-->
 						<!-- END API -->
 
 						<!-- FULL DOCS - older, full reference -->
 						<li><a href="http://bcoin.io/docs/index.html">Docs</a></li>
 						<!-- END DOCS -->
-			
-						<!-- DIVIDER 
+
+						<!-- DIVIDER
 						<li><a>&nbsp;</a></li>
-			
+
 						<li><a href="#">All Demos</a></li>-->
-			
+
 					</ul>
 				</nav>
-			
+
 			</div>
 		</header>
 	<!-- END HEADER -->
@@ -259,7 +259,7 @@
 								<li><a href="install-windows.html">Install on Windows</a></li>
 								<!--<li><a data-toggle="" href="">Quick Sync (Torrent) </a></li>-->
 							</ul>
-							<!-- guides added soon 
+							<!-- guides added soon
 							<br>
 							<h6 class="montserrat text-uppercase bottom-line">Guides</h6>
 							<ul class="icons-list">
@@ -320,7 +320,7 @@ bin/bcoin  <span class="token comment" spellcheck="true">#run</span></code></pre
 						</div>
 					</article>
 					<!-- END OF ARTICLE CONTAINER -->
-					
+
 					</div>
 					<!-- END BLOG CONTENT -->
 
@@ -338,7 +338,7 @@ bin/bcoin  <span class="token comment" spellcheck="true">#run</span></code></pre
 		</section>
 		<!-- END BLOGS -->
 
-		
+
 		<!-- PARALLAX DOCS CTA -->
 		<section class="module bg-white-alfa-30 parallax color-white" data-background="../assets/images/bg-header.jpg">
 			<div class="container">
@@ -375,16 +375,16 @@ bin/bcoin  <span class="token comment" spellcheck="true">#run</span></code></pre
 					<div class="col-sm-12 text-center m-b-35">
 						<img class="m-b-35 QR-code" src="../assets/images/donation_QR.png"/>
 						<p class="m-0"><strong>Bcoin Development Donation Address:</strong><br />3Bi9H1hzCHWJoFEjc4xzVzEMywi35dyvsV</p>
-						
+
 					</div>
 				</div>
 				<div class="row">
 					<div class="col-sm-12 text-center">
 						<p class="m-0">Copyright <a href="#">bcoin.io, Purse</a>, 2017, All Rights Reserved.</p>
-                        
+
 					</div>
 				</div>
-			
+
 			</div>
 		</footer>
 		<!-- END FOOTER -->
@@ -399,11 +399,11 @@ bin/bcoin  <span class="token comment" spellcheck="true">#run</span></code></pre
 	<script src="../assets/bootstrap/js/bootstrap.min.js"></script>
 	<script src="../assets/js/plugins.min.js"></script>
 	<script src="../assets/js/custom.min.js"></script>
-	
-	<script async defer src="../assets/js/prism.js"></script>	
-  
+
+	<script async defer src="../assets/js/prism.js"></script>
+
   <!-- github button js -->
-  <script async defer src="https://buttons.github.io/buttons.js"></script>	
-	
+  <script async defer src="https://buttons.github.io/buttons.js"></script>
+
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "doc": "docs"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "clear-guides": "rm -rf ./guides; mkdir ./guides",
     "convert-markdown": "node guide-generator.js"
   },
   "repository": {


### PR DESCRIPTION
This update will only have an effect if a user with admin rights to the repo connects with a travis-ci.org account and sets up to use with the github pages repo. This enables automatic building of guides when a commit is made to the master branch, so if new markdown is added (or existing markdown is edited) the guides will be updated automatically. The updates will be deployed to a `gh-pages` branch, which can be set as the default branch for bcoin.io if we want to use this. 