### PR TITLE
automatically add id to all header tags to allow for internal linking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,7 @@ deploy:
   file: ./*
   local_dir: .
   github_token: $GITHUB_TOKEN # Set in travis-ci.org dashboard
-  target_branch: gh-pages
+  target_branch: master
   on:
-    all_branches: true # when on actual bcoin-org repo, delete this line and uncomment lines below
-    # branch: master
-    # repo: bcoin-org/bcoin-org.github.io
+    branch: master
+    repo: bcoin-org/bcoin-org.github.io

--- a/guides.html
+++ b/guides.html
@@ -263,7 +263,7 @@
 <!-- GUIDES-LIST -->
 <li><a href="guides/scripting.html">Intro to Scripting</a></li>
 <li><a href="guides/op_return.html">Create an OP_RETURN output transaction</a></li>
-<li><a href="guides/generate-address.html">Test</a></li>
+<li><a href="guides/generate-address.html">Generate an Address</a></li>
 <!-- /GUIDES-LIST -->
 </ul>
 </div>
@@ -384,7 +384,7 @@
     </div> -->
     <div class="col-sm-10">
       <div class="post-content" style="color:#000;">
-        <h2 class="post-title"><a href="guides/generate-address.html">Test</a></h2>
+        <h2 class="post-title"><a href="guides/generate-address.html">Generate an Address</a></h2>
         <ul class="post-meta">
           <li>By Javed Khan</li>
         </ul>

--- a/guides.html
+++ b/guides.html
@@ -263,7 +263,7 @@
 <!-- GUIDES-LIST -->
 <li><a href="guides/scripting.html">Intro to Scripting</a></li>
 <li><a href="guides/op_return.html">Create an OP_RETURN output transaction</a></li>
-<li><a href="guides/generate-address.html">Generate an Address</a></li>
+<li><a href="guides/generate-address.html">Test</a></li>
 <!-- /GUIDES-LIST -->
 </ul>
 </div>
@@ -384,7 +384,7 @@
     </div> -->
     <div class="col-sm-10">
       <div class="post-content" style="color:#000;">
-        <h2 class="post-title"><a href="guides/generate-address.html">Generate an Address</a></h2>
+        <h2 class="post-title"><a href="guides/generate-address.html">Test</a></h2>
         <ul class="post-meta">
           <li>By Javed Khan</li>
         </ul>

--- a/guides/generate-address.html
+++ b/guides/generate-address.html
@@ -268,7 +268,7 @@
 <!-- GUIDES-LIST -->
 <li><a href="scripting.html">Intro to Scripting</a></li>
 <li><a href="op_return.html">Create an OP_RETURN output transaction</a></li>
-<li><a href="generate-address.html">Test</a></li>
+<li><a href="generate-address.html">Generate an Address</a></li>
 <!-- /GUIDES-LIST -->
 </ul>
 </div>
@@ -308,7 +308,7 @@
 					<!-- START OF GUIDE -->
 <h2 class="post-title panel-title" id="generate-an-address">Generate an Address</h2><ul class="post-meta"><li class="author">By Javed Khan</li></ul><p>Follow along with the steps below to build a transaction from scratch using built-in bcoin utilities. These steps are based on those outlined in the <a href="https://en.bitcoin.it/wiki/Technical_background_of_version_1_Bitcoin_addresses">Bitcoin Wiki</a>.</p>
 <p>Of course, if you&#39;re using the bcoin wallet module, it will do these steps for you automatically when you <a href="../api-docs/index.html#generate-receiving-address">generate an address</a>!</p>
-<h2 class="post-title panel-title" id="test">Test</h2><pre class="snippet line-numbers language-javascript"><code class="line-numbers language-javascript"><span class="token comment" spellcheck="true">// https://en.bitcoin.it/wiki/Technical_background_of_version_1_Bitcoin_addresses</span>
+<pre class="snippet line-numbers language-javascript"><code class="line-numbers language-javascript"><span class="token comment" spellcheck="true">// https://en.bitcoin.it/wiki/Technical_background_of_version_1_Bitcoin_addresses</span>
 
 secp256k1 <span class="token operator">=</span> <span class="token function">require</span><span class="token punctuation">(</span><span class="token string">"bcoin/lib/crypto/secp256k1"</span><span class="token punctuation">)</span>
 crypto <span class="token operator">=</span> <span class="token function">require</span><span class="token punctuation">(</span><span class="token string">"bcoin/lib/crypto"</span><span class="token punctuation">)</span>
@@ -342,8 +342,7 @@ step7 <span class="token operator">=</span> step6<span class="token punctuation"
 step8 <span class="token operator">=</span> buffer<span class="token punctuation">.</span>Buffer<span class="token punctuation">.</span><span class="token function">concat</span><span class="token punctuation">(</span><span class="token punctuation">[</span>step4<span class="token punctuation">,</span> step7<span class="token punctuation">]</span><span class="token punctuation">)</span>
 
 <span class="token comment" spellcheck="true">// 9 - Convert the result from a byte string into a base58 string using Base58Check encoding. This is the most commonly used Bitcoin Address format</span>
-addr <span class="token operator">=</span> base58<span class="token punctuation">.</span><span class="token function">encode</span><span class="token punctuation">(</span>step8<span class="token punctuation">)</span></code><button class="copy-button"><img src="../assets/images/clippy.svg" alt="Copy to clipboard"></button></pre><p><a href="#test">Link to header above</a></p>
-
+addr <span class="token operator">=</span> base58<span class="token punctuation">.</span><span class="token function">encode</span><span class="token punctuation">(</span>step8<span class="token punctuation">)</span></code><button class="copy-button"><img src="../assets/images/clippy.svg" alt="Copy to clipboard"></button></pre>
 
 					<!-- END OF GUIDE -->
 									</div>

--- a/guides/generate-address.html
+++ b/guides/generate-address.html
@@ -268,7 +268,7 @@
 <!-- GUIDES-LIST -->
 <li><a href="scripting.html">Intro to Scripting</a></li>
 <li><a href="op_return.html">Create an OP_RETURN output transaction</a></li>
-<li><a href="generate-address.html">Generate an Address</a></li>
+<li><a href="generate-address.html">Test</a></li>
 <!-- /GUIDES-LIST -->
 </ul>
 </div>
@@ -306,9 +306,9 @@
 									<div class="col-sm-12 panel panel-default">
 										<div class="post-content" style="color:#000;">
 					<!-- START OF GUIDE -->
-<h2 class="post-title panel-title">Generate an Address</h2><ul class="post-meta"><li class="author">By Javed Khan</li></ul><p>Follow along with the steps below to build a transaction from scratch using built-in bcoin utilities. These steps are based on those outlined in the <a href="https://en.bitcoin.it/wiki/Technical_background_of_version_1_Bitcoin_addresses">Bitcoin Wiki</a>.</p>
+<h2 class="post-title panel-title" id="generate-an-address">Generate an Address</h2><ul class="post-meta"><li class="author">By Javed Khan</li></ul><p>Follow along with the steps below to build a transaction from scratch using built-in bcoin utilities. These steps are based on those outlined in the <a href="https://en.bitcoin.it/wiki/Technical_background_of_version_1_Bitcoin_addresses">Bitcoin Wiki</a>.</p>
 <p>Of course, if you&#39;re using the bcoin wallet module, it will do these steps for you automatically when you <a href="../api-docs/index.html#generate-receiving-address">generate an address</a>!</p>
-<pre class="snippet line-numbers language-javascript"><code class="line-numbers language-javascript"><span class="token comment" spellcheck="true">// https://en.bitcoin.it/wiki/Technical_background_of_version_1_Bitcoin_addresses</span>
+<h2 class="post-title panel-title" id="test">Test</h2><pre class="snippet line-numbers language-javascript"><code class="line-numbers language-javascript"><span class="token comment" spellcheck="true">// https://en.bitcoin.it/wiki/Technical_background_of_version_1_Bitcoin_addresses</span>
 
 secp256k1 <span class="token operator">=</span> <span class="token function">require</span><span class="token punctuation">(</span><span class="token string">"bcoin/lib/crypto/secp256k1"</span><span class="token punctuation">)</span>
 crypto <span class="token operator">=</span> <span class="token function">require</span><span class="token punctuation">(</span><span class="token string">"bcoin/lib/crypto"</span><span class="token punctuation">)</span>
@@ -342,7 +342,8 @@ step7 <span class="token operator">=</span> step6<span class="token punctuation"
 step8 <span class="token operator">=</span> buffer<span class="token punctuation">.</span>Buffer<span class="token punctuation">.</span><span class="token function">concat</span><span class="token punctuation">(</span><span class="token punctuation">[</span>step4<span class="token punctuation">,</span> step7<span class="token punctuation">]</span><span class="token punctuation">)</span>
 
 <span class="token comment" spellcheck="true">// 9 - Convert the result from a byte string into a base58 string using Base58Check encoding. This is the most commonly used Bitcoin Address format</span>
-addr <span class="token operator">=</span> base58<span class="token punctuation">.</span><span class="token function">encode</span><span class="token punctuation">(</span>step8<span class="token punctuation">)</span></code><button class="copy-button"><img src="../assets/images/clippy.svg" alt="Copy to clipboard"></button></pre>
+addr <span class="token operator">=</span> base58<span class="token punctuation">.</span><span class="token function">encode</span><span class="token punctuation">(</span>step8<span class="token punctuation">)</span></code><button class="copy-button"><img src="../assets/images/clippy.svg" alt="Copy to clipboard"></button></pre><p><a href="#test">Link to header above</a></p>
+
 
 					<!-- END OF GUIDE -->
 									</div>

--- a/guides/install-linux.html
+++ b/guides/install-linux.html
@@ -268,7 +268,7 @@
 <!-- GUIDES-LIST -->
 <li><a href="scripting.html">Intro to Scripting</a></li>
 <li><a href="op_return.html">Create an OP_RETURN output transaction</a></li>
-<li><a href="generate-address.html">Test</a></li>
+<li><a href="generate-address.html">Generate an Address</a></li>
 <!-- /GUIDES-LIST -->
 </ul>
 </div>

--- a/guides/install-linux.html
+++ b/guides/install-linux.html
@@ -268,7 +268,7 @@
 <!-- GUIDES-LIST -->
 <li><a href="scripting.html">Intro to Scripting</a></li>
 <li><a href="op_return.html">Create an OP_RETURN output transaction</a></li>
-<li><a href="generate-address.html">Generate an Address</a></li>
+<li><a href="generate-address.html">Test</a></li>
 <!-- /GUIDES-LIST -->
 </ul>
 </div>
@@ -306,15 +306,15 @@
 									<div class="col-sm-12 panel panel-default">
 										<div class="post-content" style="color:#000;">
 					<!-- START OF GUIDE -->
-<h2 class="post-title panel-title"><i class="fa fa-linux"></i>Install on Linux (Video)</h2><ul class="post-meta"><li class="author">By HeKaz</li></ul><p>A quick step-by-step video to learn the basics of running a bcoin fullnode on Linux.</p>
+<h2 class="post-title panel-title" id="install-on-linux"><i class="fa fa-linux"></i>Install on Linux (Video)</h2><ul class="post-meta"><li class="author">By HeKaz</li></ul><p>A quick step-by-step video to learn the basics of running a bcoin fullnode on Linux.</p>
 <div class="post-video">
   <iframe width="100%" height="315" src="https://www.youtube.com/embed/tRICg7kJvpo" frameborder="0" allowfullscreen></iframe>
 </div>
 
-<h6>Source Install (Requires: Node &gt;= 7.6)</h6><pre class="snippet line-numbers language-bash"><code class="line-numbers language-bash"><span class="token function">git</span> clone https://github.com/bcoin-org/bcoin.git
+<h6 id="source-install">Source Install (Requires: Node &gt;= 7.6)</h6><pre class="snippet line-numbers language-bash"><code class="line-numbers language-bash"><span class="token function">git</span> clone https://github.com/bcoin-org/bcoin.git
 <span class="token function">cd</span> bcoin
 npm <span class="token function">install</span>
-bin/bcoin  <span class="token comment" spellcheck="true">#run</span></code><button class="copy-button"><img src="../assets/images/clippy.svg" alt="Copy to clipboard"></button></pre><h6>Archlinux AUR Package</h6><pre class="snippet line-numbers language-bash"><code class="line-numbers language-bash">yaourt -S bcoin-git</code><button class="copy-button"><img src="../assets/images/clippy.svg" alt="Copy to clipboard"></button></pre><p>Pkg Source:
+bin/bcoin  <span class="token comment" spellcheck="true">#run</span></code><button class="copy-button"><img src="../assets/images/clippy.svg" alt="Copy to clipboard"></button></pre><h6 id="archlinux-aur-package">Archlinux AUR Package</h6><pre class="snippet line-numbers language-bash"><code class="line-numbers language-bash">yaourt -S bcoin-git</code><button class="copy-button"><img src="../assets/images/clippy.svg" alt="Copy to clipboard"></button></pre><p>Pkg Source:
 <a href="https://aur.archlinux.org/packages/bcoin-git/">https://aur.archlinux.org/packages/bcoin-git/</a></p>
 
 

--- a/guides/install-mac.html
+++ b/guides/install-mac.html
@@ -268,7 +268,7 @@
 <!-- GUIDES-LIST -->
 <li><a href="scripting.html">Intro to Scripting</a></li>
 <li><a href="op_return.html">Create an OP_RETURN output transaction</a></li>
-<li><a href="generate-address.html">Test</a></li>
+<li><a href="generate-address.html">Generate an Address</a></li>
 <!-- /GUIDES-LIST -->
 </ul>
 </div>

--- a/guides/install-mac.html
+++ b/guides/install-mac.html
@@ -268,7 +268,7 @@
 <!-- GUIDES-LIST -->
 <li><a href="scripting.html">Intro to Scripting</a></li>
 <li><a href="op_return.html">Create an OP_RETURN output transaction</a></li>
-<li><a href="generate-address.html">Generate an Address</a></li>
+<li><a href="generate-address.html">Test</a></li>
 <!-- /GUIDES-LIST -->
 </ul>
 </div>
@@ -306,12 +306,12 @@
 									<div class="col-sm-12 panel panel-default">
 										<div class="post-content" style="color:#000;">
 					<!-- START OF GUIDE -->
-<h2 class="post-title panel-title"><i class="fa fa-apple"></i>Install on Mac OS (Video)</h2><ul class="post-meta"><li class="author">By HeKaz</li></ul><p>A quick step-by-step video to learn the basics of running a bcoin fullnode on a Mac.</p>
+<h2 class="post-title panel-title" id="install-on-mac-os"><i class="fa fa-apple"></i>Install on Mac OS (Video)</h2><ul class="post-meta"><li class="author">By HeKaz</li></ul><p>A quick step-by-step video to learn the basics of running a bcoin fullnode on a Mac.</p>
 <div class="post-video">
   <iframe width="100%" height="315" src="https://www.youtube.com/embed/TWjucnmYSKY" frameborder="0" allowfullscreen></iframe>
 </div>
 
-<h6>Source Install (Requires: Node &gt;= 7.6)</h6><pre class="snippet line-numbers language-bash"><code class="line-numbers language-bash"><span class="token function">git</span> clone https://github.com/bcoin-org/bcoin.git
+<h6 id="source-install">Source Install (Requires: Node &gt;= 7.6)</h6><pre class="snippet line-numbers language-bash"><code class="line-numbers language-bash"><span class="token function">git</span> clone https://github.com/bcoin-org/bcoin.git
 <span class="token function">cd</span> bcoin
 npm <span class="token function">install</span>
 bin/bcoin  <span class="token comment" spellcheck="true">#run</span></code><button class="copy-button"><img src="../assets/images/clippy.svg" alt="Copy to clipboard"></button></pre>

--- a/guides/install-windows.html
+++ b/guides/install-windows.html
@@ -268,7 +268,7 @@
 <!-- GUIDES-LIST -->
 <li><a href="scripting.html">Intro to Scripting</a></li>
 <li><a href="op_return.html">Create an OP_RETURN output transaction</a></li>
-<li><a href="generate-address.html">Test</a></li>
+<li><a href="generate-address.html">Generate an Address</a></li>
 <!-- /GUIDES-LIST -->
 </ul>
 </div>

--- a/guides/install-windows.html
+++ b/guides/install-windows.html
@@ -268,7 +268,7 @@
 <!-- GUIDES-LIST -->
 <li><a href="scripting.html">Intro to Scripting</a></li>
 <li><a href="op_return.html">Create an OP_RETURN output transaction</a></li>
-<li><a href="generate-address.html">Generate an Address</a></li>
+<li><a href="generate-address.html">Test</a></li>
 <!-- /GUIDES-LIST -->
 </ul>
 </div>
@@ -306,12 +306,12 @@
 									<div class="col-sm-12 panel panel-default">
 										<div class="post-content" style="color:#000;">
 					<!-- START OF GUIDE -->
-<h2 class="post-title panel-title"><i class="fa fa-windows"></i>Install on Windows (Video)</h2><ul class="post-meta"><li class="author">By HeKaz</li></ul><p>A quick step-by-step video to learn the basics of running a bcoin fullnode on a Windows.</p>
+<h2 class="post-title panel-title" id="install-on-windows"><i class="fa fa-windows"></i>Install on Windows (Video)</h2><ul class="post-meta"><li class="author">By HeKaz</li></ul><p>A quick step-by-step video to learn the basics of running a bcoin fullnode on a Windows.</p>
 <div class="post-video">
   <iframe width="100%" height="315" src="https://www.youtube.com/embed/H6T72CJ50M8" frameborder="0" allowfullscreen></iframe>
 </div>
 
-<h6>Source Install (Requires: Node &gt;= 7.6)</h6><pre class="snippet line-numbers language-bash"><code class="line-numbers language-bash"><span class="token function">git</span> clone https://github.com/bcoin-org/bcoin.git
+<h6 id="source-install">Source Install (Requires: Node &gt;= 7.6)</h6><pre class="snippet line-numbers language-bash"><code class="line-numbers language-bash"><span class="token function">git</span> clone https://github.com/bcoin-org/bcoin.git
 <span class="token function">cd</span> bcoin
 npm <span class="token function">install</span>
 bin/bcoin  <span class="token comment" spellcheck="true">#run</span></code><button class="copy-button"><img src="../assets/images/clippy.svg" alt="Copy to clipboard"></button></pre>

--- a/guides/op_return.html
+++ b/guides/op_return.html
@@ -268,7 +268,7 @@
 <!-- GUIDES-LIST -->
 <li><a href="scripting.html">Intro to Scripting</a></li>
 <li><a href="op_return.html">Create an OP_RETURN output transaction</a></li>
-<li><a href="generate-address.html">Test</a></li>
+<li><a href="generate-address.html">Generate an Address</a></li>
 <!-- /GUIDES-LIST -->
 </ul>
 </div>

--- a/guides/op_return.html
+++ b/guides/op_return.html
@@ -268,7 +268,7 @@
 <!-- GUIDES-LIST -->
 <li><a href="scripting.html">Intro to Scripting</a></li>
 <li><a href="op_return.html">Create an OP_RETURN output transaction</a></li>
-<li><a href="generate-address.html">Generate an Address</a></li>
+<li><a href="generate-address.html">Test</a></li>
 <!-- /GUIDES-LIST -->
 </ul>
 </div>
@@ -306,7 +306,7 @@
 									<div class="col-sm-12 panel panel-default">
 										<div class="post-content" style="color:#000;">
 					<!-- START OF GUIDE -->
-<h2 class="post-title panel-title">Create an OP_RETURN output transaction</h2><ul class="post-meta"><li class="author">By Javed Khan</li></ul><p>OP_RETURN is a script opcode which can be used to store an arbitrary 40-byte
+<h2 class="post-title panel-title" id="create-an-op_return-output-transaction">Create an OP_RETURN output transaction</h2><ul class="post-meta"><li class="author">By Javed Khan</li></ul><p>OP_RETURN is a script opcode which can be used to store an arbitrary 40-byte
 data as a part of the signature script (null data script), allowing one to
 embed a small amount of data into the blockchain. For example, it can be used
 as a way to track digital assets or certify a document with proof-of-existence.

--- a/guides/scripting.html
+++ b/guides/scripting.html
@@ -268,7 +268,7 @@
 <!-- GUIDES-LIST -->
 <li><a href="scripting.html">Intro to Scripting</a></li>
 <li><a href="op_return.html">Create an OP_RETURN output transaction</a></li>
-<li><a href="generate-address.html">Test</a></li>
+<li><a href="generate-address.html">Generate an Address</a></li>
 <!-- /GUIDES-LIST -->
 </ul>
 </div>

--- a/guides/scripting.html
+++ b/guides/scripting.html
@@ -268,7 +268,7 @@
 <!-- GUIDES-LIST -->
 <li><a href="scripting.html">Intro to Scripting</a></li>
 <li><a href="op_return.html">Create an OP_RETURN output transaction</a></li>
-<li><a href="generate-address.html">Generate an Address</a></li>
+<li><a href="generate-address.html">Test</a></li>
 <!-- /GUIDES-LIST -->
 </ul>
 </div>
@@ -306,7 +306,7 @@
 									<div class="col-sm-12 panel panel-default">
 										<div class="post-content" style="color:#000;">
 					<!-- START OF GUIDE -->
-<h2 class="post-title panel-title">Intro to Scripting</h2><ul class="post-meta"><li class="author">By Christopher Jeffery</li></ul><p>Scripts are array-like objects with some helper functions.</p>
+<h2 class="post-title panel-title" id="intro-to-scripting">Intro to Scripting</h2><ul class="post-meta"><li class="author">By Christopher Jeffery</li></ul><p>Scripts are array-like objects with some helper functions.</p>
 <pre class="snippet line-numbers language-javascript"><code class="line-numbers language-javascript"><span class="token keyword">var</span> bcoin <span class="token operator">=</span> <span class="token function">require</span><span class="token punctuation">(</span><span class="token string">'bcoin'</span><span class="token punctuation">)</span><span class="token punctuation">;</span>
 <span class="token keyword">var</span> assert <span class="token operator">=</span> <span class="token function">require</span><span class="token punctuation">(</span><span class="token string">'assert'</span><span class="token punctuation">)</span><span class="token punctuation">;</span>
 <span class="token keyword">var</span> BN <span class="token operator">=</span> bcoin<span class="token punctuation">.</span>bn<span class="token punctuation">;</span>

--- a/utils/createHTML.js
+++ b/utils/createHTML.js
@@ -24,9 +24,16 @@ const createHTML = async function createHTML(markdownFile, htmlFile, author, pos
 
   // Custom renderer for top two level headers
   renderer.heading = (text, level) => {
+    let textURL = text.replace(/\(.+\)/, '').trim(); // for url remove any parentheses and their contents
+    textURL = textURL.replace(/ /g, '-').toLowerCase(); // and replace spaces with dashes
+
     if (level == '2' || level == '1' ) {
-      let header = '<h2 class="post-title panel-title">'
-             + text + '</h2>';
+      // remove icon tag for the url
+      const iconCloseTagIndex = textURL.indexOf('</i>');
+      if (iconCloseTagIndex > -1) {
+        textURL = textURL.slice(iconCloseTagIndex + 4, textURL.length);
+      }
+      let header = `<h2 class="post-title panel-title" id="${textURL}">${text}</h2>`;
 
       if (author) {
         postMeta = getPostMeta(author)
@@ -35,7 +42,7 @@ const createHTML = async function createHTML(markdownFile, htmlFile, author, pos
       guideTitle = text;
       return header;
     } else {
-      return `<h${level}>${text}</h${level}>`;
+      return `<h${level} id="${textURL}">${text}</h${level}>`;
     }
   }
 


### PR DESCRIPTION
Basically this just adds an id that matches with the title (converted to lowercase, removing anything in parentheses, and replacing spaces with dashes) so that you can link internally within a guide to headers via the markdown. This is useful for long guides (like the advanced crowdfund tx ones currently in PR) where you want to link to somewhere earlier in the guide.