### PR TITLE
Update indexing notes

### DIFF
--- a/api-docs-slate/source/includes/_coin.md
+++ b/api-docs-slate/source/includes/_coin.md
@@ -1,17 +1,18 @@
 # Coin
-Getting coin information via APi.
+Getting coin information via API.
 
 *Coin stands for UTXO*
 
 <aside class="info">
-You need to enable <code>index-tx</code> in order
-to lookup transactions by transaction hashes and also
-enable <code>index-address</code> to lookup transaction by
-addresses too.
+You need to enable <code>index-address</code> in order to lookup coins by address(es).
 </aside>
 
 
 ## Get coin by Outpoint
+
+<aside class="info">
+This API call is always available regardless indexing options.
+</aside>
 
 ```javascript
 let hash, index;

--- a/api-docs-slate/source/includes/_coin.md
+++ b/api-docs-slate/source/includes/_coin.md
@@ -4,8 +4,10 @@ Getting coin information via APi.
 *Coin stands for UTXO*
 
 <aside class="info">
-You need to enable <code>index-tx</code> and <code>index-address</code> in order
-to lookup coins by transaction hashes and addresses, respectively.
+You need to enable <code>index-tx</code> in order
+to lookup transactions by transaction hashes and also
+enable <code>index-address</code> to lookup transaction by
+addresses too.
 </aside>
 
 

--- a/api-docs-slate/source/includes/_transaction.md
+++ b/api-docs-slate/source/includes/_transaction.md
@@ -1,5 +1,5 @@
 # Transaction
-Getting transaction information via APi.
+Getting transaction information via API.
 
 <aside class="info">
 You need to enable <code>index-tx</code> in order

--- a/api-docs-slate/source/includes/_transaction.md
+++ b/api-docs-slate/source/includes/_transaction.md
@@ -2,8 +2,10 @@
 Getting transaction information via APi.
 
 <aside class="info">
-You need to enable <code>index-tx</code> and <code>index-address</code> in order
-to lookup transactions by transaction hashes and addresses, respectively.
+You need to enable <code>index-tx</code> in order
+to lookup transactions by transaction hashes and also
+enable <code>index-address</code> to lookup transaction by
+addresses too.
 </aside>
 
 ## Get tx by txhash


### PR DESCRIPTION
Clarifies indexing options:
 * Get coins by outpoints is always available
 * Coins API calls only need `index-address` for getting coins by addresses.
 * Getting transactions by tx hash need `index-tx`
 * Getting transactions by address need both `index-tx` and `index-address`
