### PR TITLE
Remove stray schmutz

### DIFF
--- a/guides-markdown/scripting.md
+++ b/guides-markdown/scripting.md
@@ -38,7 +38,7 @@ input.compile();
 // only Buffers (whereas scripts contain Opcode objects).
 const stack = new Stack();
 input.execute(stack);
-output.execute(stack)bcoin;
+output.execute(stack);
 // Verify the script was successful in its execution:
 assert(stack.length === 1);
 assert(stack.getBool(-1) === true);


### PR DESCRIPTION
I think more could be done in the way of adding comments describing what's up, specifically around the pattern `input.execute(stack)`  followed by `output.execute(stack);`

If that's of interest I'll make a separate stab as a PR. 