### PR TITLE
Fix typo in "building plugins" title

### DIFF
--- a/guides-markdown/building-plugins.md
+++ b/guides-markdown/building-plugins.md
@@ -1,4 +1,4 @@
-# Buidling Awesome bcoin Plugins
+# Building Awesome bcoin Plugins
 
 ```post-author
 Javed Khan


### PR DESCRIPTION
Was "Buidling" instead of "Building"