### PR TITLE
Events guide: Wallet event only emits tx-details

### DIFF
--- a/guides-markdown/events.md
+++ b/guides-markdown/events.md
@@ -259,10 +259,10 @@ All wallet events are emitted by a `WalletDB` object, which may have been trigge
 
 | Event | Returns |
 |-|-|
-| `tx` | WalletID, [TX](https://github.com/bcoin-org/bcoin/blob/master/lib/primitives/tx.js), [Details](https://github.com/bcoin-org/bcoin/blob/master/lib/wallet/txdb.js) |
-| `confirmed` | WalletID, [TX](https://github.com/bcoin-org/bcoin/blob/master/lib/primitives/tx.js), [Details](https://github.com/bcoin-org/bcoin/blob/master/lib/wallet/txdb.js) |
-| `unconfirmed` | WalletID, [TX](https://github.com/bcoin-org/bcoin/blob/master/lib/primitives/tx.js), [Details](https://github.com/bcoin-org/bcoin/blob/master/lib/wallet/txdb.js) |
-| `conflict` | WalletID, [TX](https://github.com/bcoin-org/bcoin/blob/master/lib/primitives/tx.js), [Details](https://github.com/bcoin-org/bcoin/blob/master/lib/wallet/txdb.js)|
+| `tx` | WalletID, [TX Details](https://github.com/bcoin-org/bcoin/blob/master/lib/wallet/txdb.js) |
+| `confirmed` | WalletID, [TX Details](https://github.com/bcoin-org/bcoin/blob/master/lib/wallet/txdb.js) |
+| `unconfirmed` | WalletID, [TX Details](https://github.com/bcoin-org/bcoin/blob/master/lib/wallet/txdb.js) |
+| `conflict` | WalletID, [TX Details](https://github.com/bcoin-org/bcoin/blob/master/lib/wallet/txdb.js)|
 | `balance` | WalletID, [Balance](https://github.com/bcoin-org/bcoin/blob/master/lib/wallet/txdb.js) |
 | `address` | WalletID, [[WalletKey](https://github.com/bcoin-org/bcoin/blob/master/lib/wallet/walletkey.js)] |
 


### PR DESCRIPTION
Quick update!

See https://github.com/bcoin-org/bcoin/blob/master/lib/wallet/http.js#L866-L879

Wallet events that get emitted out the socket return `wallet-id` and a `details` object only. The `TX` object is ignored by the socket-emitting handler.