### PR TITLE
api-docs: update wallet client and options

### DIFF
--- a/api-docs-slate/source/stylesheets/_custom.scss
+++ b/api-docs-slate/source/stylesheets/_custom.scss
@@ -43,6 +43,10 @@
   background-color: #c0b3f3;
 }
 
+.content code {
+  white-space: pre;
+}
+
 .toc-wrapper .toc-link.active {
   background-color: #5659dc;
 }


### PR DESCRIPTION
Addresses https://github.com/bcoin-org/bcoin-org.github.io/issues/80 by including `passphrase` in the wallet options. This also replaces `receiveDepth` and `changeDepth` with `accountDepth` [which was changed in the code](https://github.com/bcoin-org/bcoin/commit/976fd46da5d7c1064ed3184c90ca2d9d05e3354a) about 2 years ago 😬

Some parameters for `createWallet` are [not avail to the http API](https://github.com/bcoin-org/bcoin/blob/master/lib/wallet/http.js#L274-L285) and I've indicated that as well.

Picked a few nits with grammar and capitalization. Put the wallet options chart in the actual parameter list for `create a wallet` (they were separated by a few pages before), and finally rearranged the order of the sections in the wallet doc so it read top-down if this was your first time ever using a wallet in bcoin:

1. The wallet client
2. Configuration
3. Wallet Auth
4. The WalletDB and Object
5. Create a wallet
6. ... (actual API calls)...

Oh and I also through in a new CSS rule: 
```
.content code {
  white-space: pre;
}
```
So commands like `npm install -g bcoin` wouldn't get chopped up by line breaks in the middle of text paragraphs




