### PR TITLE
fix long-line code css

### DIFF
--- a/api-docs-slate/source/stylesheets/_custom.scss
+++ b/api-docs-slate/source/stylesheets/_custom.scss
@@ -44,7 +44,12 @@
 }
 
 .content code {
-  white-space: pre;
+  hyphens: none;
+  word-break: break-word;
+}
+
+table code {
+    white-space: pre;
 }
 
 .toc-wrapper .toc-link.active {


### PR DESCRIPTION
This is an update to a CSS fix I merged a while back, but neglected to test on small screens!

This PR breaks long lines of code, but without hyphens. Then I added back the line that prevents line breaks if a word is too long, but only in tables, where it seems to look the worst:

### Before:
<img width="802" alt="screen shot 2018-12-21 at 10 45 06 am" src="https://user-images.githubusercontent.com/2084648/50358559-a0627980-050e-11e9-981d-5cb46cd017e9.png">
<img width="414" alt="screen shot 2018-12-21 at 10 44 19 am" src="https://user-images.githubusercontent.com/2084648/50358560-a0627980-050e-11e9-98a9-2ef003b60b36.png">

### After:
<img width="723" alt="screen shot 2018-12-21 at 10 45 16 am" src="https://user-images.githubusercontent.com/2084648/50358566-a6f0f100-050e-11e9-98a2-b80fe26c84ef.png">
<img width="445" alt="screen shot 2018-12-21 at 10 44 33 am" src="https://user-images.githubusercontent.com/2084648/50358567-a6f0f100-050e-11e9-8960-0e50870f8c00.png">

### Prevents regression:
<img width="416" alt="screen shot 2018-12-21 at 10 50 11 am" src="https://user-images.githubusercontent.com/2084648/50358584-b53f0d00-050e-11e9-858c-dfa824ff4c47.png">
