### PR TITLE
api-docs: explain wallet-auth

### DIFF
--- a/api-docs-slate/source/includes/_clients.md
+++ b/api-docs-slate/source/includes/_clients.md
@@ -74,7 +74,7 @@ These files may contain any of the configuration parameters, and will be interpr
 
 [A sample bcoin.conf file is included in the code repository](https://github.com/bcoin-org/bcoin/blob/master/etc/sample.conf)
 
-[Detailed configuration documentation is available in docs/Configuration](https://github.com/bcoin-org/bcoin/blob/master/docs/Configuration.md)
+[Detailed configuration documentation is available in docs/configuration](https://github.com/bcoin-org/bcoin/blob/master/docs/configuration.md)
 
 
 

--- a/api-docs-slate/source/index.html.md
+++ b/api-docs-slate/source/index.html.md
@@ -111,7 +111,7 @@ at launch (for example):<br>
 <code>bcoin --api-key=92ded8555d6f04e440ba540f2221349cbf799c454f7e08d3f16577d3e0127b0e</code><br>
 <br>
 For more information about <code>bcoin.conf</code> and other launch paramaters, see
-<a href="https://github.com/bcoin-org/bcoin/blob/master/docs/Configuration.md">docs/Configuration</a>.
+<a href="https://github.com/bcoin-org/bcoin/blob/master/docs/configuration.md">docs/Configuration</a>.
 </aside>
 
 <aside class="warning">

--- a/guides-markdown/beginners.md
+++ b/guides-markdown/beginners.md
@@ -151,4 +151,4 @@ Note: Selfish mode is not recommended. We encourage you to _help_ the network by
 
 ## Further Configuration
 
-See [Configuration](https://github.com/bcoin-org/bcoin/blob/master/docs/Configuration.md).
+See [Configuration](https://github.com/bcoin-org/bcoin/blob/master/docs/configuration.md).


### PR DESCRIPTION
I interacted with a user on slack who was confused about the purpose and interaction of API keys, wallet/admin tokens and the `wallet-auth` parameter. I think this addition to the api-docs lays it all out pretty clearly.

Bonus: fixed all the broken links to bcoin docs/configuration which is spelled with a lower-case 'c' now since https://github.com/bcoin-org/bcoin/pull/713