### PR TITLE
api-docs: add reset

### DIFF
--- a/api-docs-slate/source/includes/_node.md
+++ b/api-docs-slate/source/includes/_node.md
@@ -318,3 +318,65 @@ Broadcast a transaction by adding it to the node's mempool. If mempool verificat
 Parameter | Description
 --------- | -----------
 tx | transaction hash
+
+
+
+## Reset blockchain
+```javascript
+let height;
+```
+
+```shell--vars
+height=1000;
+```
+
+```shell--curl
+curl $url/reset \
+  -H 'Content-Type: application/json' \
+  -X POST \
+  --data '{ "height": '$height' }'
+```
+
+```shell--cli
+bcoin-cli reset $height
+```
+
+```javascript
+const {NodeClient} = require('bclient');
+const {Network} = require('bcoin');
+const network = Network.get('regtest');
+
+const clientOptions = {
+  network: network.type,
+  port: network.rpcPort,
+  apiKey: 'api-key'
+}
+
+const client = new NodeClient(clientOptions);
+
+(async () => {
+  const result = await client.reset(height);
+  console.log(result);
+})();
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "success": true
+}
+```
+
+Triggers a hard-reset of the blockchain. All blocks are disconnected from the tip
+down to the provided height. Indexes and Chain Entries are removed. Useful for
+"rescanning" an SPV wallet. Since there are no blocks stored on disk, the only
+way to rescan the blockchain is to re-request [merkle]blocks from peers.
+
+### HTTP Request
+`POST /reset`
+
+### POST Parameters (JSON)
+Parameter | Description
+--------- | -----------
+height | block height to reset chain to 

--- a/api-docs-slate/source/includes/_wallet_admin.md
+++ b/api-docs-slate/source/includes/_wallet_admin.md
@@ -62,7 +62,9 @@ const walletClient = new WalletClient(walletOptions);
 {"success": true}
 ```
 
-Initiates a blockchain rescan for the walletdb. Wallets will be rolled back to the specified height (transactions above this height will be unconfirmed).
+Initiates a blockchain rescan for the walletdb. Wallets will be rolled back to the specified height (transactions above this height will be unconfirmed). For SPV nodes, a wallet
+reascan will be ineffective since there are no blocks stored on disk. Therefore a
+chain [`reset`](#reset-blockchain) must be called instead.
 
 ### Example HTTP Request
 `POST /rescan?height=50`


### PR DESCRIPTION
The `reset` command has been missing from the api-docs.

It was originally documented only in an older version of `bcoin/docs/CLI.md` that was cleared out in the recent docs overhaul: https://github.com/bcoin-org/bcoin/commit/c64ccf215e527f4588bf767312afc9668bc3c75a

I'm not sure if it was kept of the website docs for a reason, but it is useful (essential actually) for wallet rescans in SPV mode. I've walked a few users through it on slack.