### PR TITLE
api-docs: updates for 2.0.0-dev

### DIFF
--- a/api-docs-slate/source/includes/_coin.md
+++ b/api-docs-slate/source/includes/_coin.md
@@ -50,12 +50,12 @@ const client = new NodeClient(clientOptions);
 ```json
 {
   "version": 1,
-  "height": -1,
-  "value": 30000000,
-  "script": "76a91400ba915c3d18907b79e6cfcd8b9fdf69edc7a7db88ac",
-  "address": "R9M3aUWCcKoiqDPusJvqNkAbjffLgCqYip",
+  "height": 533,
+  "value": 67377,
+  "script": "76a9147356fde8f0a321dd114d947495d1f4b9f3cb050088ac",
+  "address": "mr2pDQvLN7eGv6xinBgSUmQpYSYdTEWyTf",
   "coinbase": false,
-  "hash": "53faa103e8217e1520f5149a4e8c84aeb58e55bdab11164a95e69a8ca50f8fcc",
+  "hash": "c747afe7aea229ae2aed7135eb768fd2dc1d8172cd7463bf3906e8321baa5608",
   "index": 0
 }
 ```

--- a/api-docs-slate/source/includes/_coin.md
+++ b/api-docs-slate/source/includes/_coin.md
@@ -28,8 +28,7 @@ bcoin-cli coin $hash $index
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {

--- a/api-docs-slate/source/includes/_node.md
+++ b/api-docs-slate/source/includes/_node.md
@@ -169,8 +169,8 @@ let blockHash, blockHeight;
 ```
 
 ```shell--vars
-blockHash='4003e57eb1c60f3d1b774d8a281353c35cd30dca0d76b751c8dd862da11c41de';
-blockHeight='94';
+blockHash='78f86c294d1ffc640f1783e2b3cc3dcdfbe1da9fe885f35de286f94db8cfac72';
+blockHeight='50';
 ```
 
 ```shell--curl
@@ -207,22 +207,22 @@ const client = new NodeClient(clientOptions);
 
 ```json
 {
-  "hash": "4003e57eb1c60f3d1b774d8a281353c35cd30dca0d76b751c8dd862da11c41de",
-  "height": 94,
-  "depth": 112,
+  "hash": "78f86c294d1ffc640f1783e2b3cc3dcdfbe1da9fe885f35de286f94db8cfac72",
+  "height": 50,
+  "depth": 484,
   "version": 536870912,
-  "prevBlock": "353cbab0d0ae1583ceb6bd88d90f44a7bb2cb2aec824eac688dbf1832e648962",
-  "merkleRoot": "b23e398ccf2fe2dcf81c6e7b4cc3c710a79c78bf7e8a63dd819acf83952f960f",
-  "time": 1527028558,
+  "prevBlock": "4e186ead55dfe014baee8bab96805c88c03032ba1e92be86709ca9f65ea5003a",
+  "merkleRoot": "5bca36ac149947e8f545d28ae2d34b6f6f170d36dd5289766e08813f5d183678",
+  "time": 1571759960,
   "bits": 545259519,
-  "nonce": 4,
+  "nonce": 0,
   "txs": [
     {
-      "hash": "b23e398ccf2fe2dcf81c6e7b4cc3c710a79c78bf7e8a63dd819acf83952f960f",
-      "witnessHash": "b23e398ccf2fe2dcf81c6e7b4cc3c710a79c78bf7e8a63dd819acf83952f960f",
+      "hash": "5bca36ac149947e8f545d28ae2d34b6f6f170d36dd5289766e08813f5d183678",
+      "witnessHash": "c3401a27680aebb0603f50c0bafbe22c492ec9e65aea754a179f10b3f537d2c6",
       "fee": 0,
       "rate": 0,
-      "mtime": 1527028763,
+      "mtime": 1571762225,
       "index": 0,
       "version": 1,
       "inputs": [
@@ -231,8 +231,8 @@ const client = new NodeClient(clientOptions);
             "hash": "0000000000000000000000000000000000000000000000000000000000000000",
             "index": 4294967295
           },
-          "script": "015e0e6d696e65642062792062636f696e04899fe44e080000000000000000",
-          "witness": "00",
+          "script": "01320e6d696e65642062792062636f696e0431d5f7bf080000000000000000",
+          "witness": "01200000000000000000000000000000000000000000000000000000000000000000",
           "sequence": 4294967295,
           "address": null
         }
@@ -240,12 +240,17 @@ const client = new NodeClient(clientOptions);
       "outputs": [
         {
           "value": 5000000000,
-          "script": "76a91420a060fec9a7dfac723c521e168876909aa37ce588ac",
-          "address": "RCFhpyWXkz5GxskL96q4KtceRXuAMnWUQo"
+          "script": "76a91415f34e5cc7c4d7cc5a896611af8fb242847e003d88ac",
+          "address": "mhX1xHbKGzw3r8FoN5bUkmRixHPEDNywxh"
+        },
+        {
+          "value": 0,
+          "script": "6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9",
+          "address": null
         }
       ],
       "locktime": 0,
-      "hex": "01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff1f015e0e6d696e65642062792062636f696e04899fe44e080000000000000000ffffffff0100f2052a010000001976a91420a060fec9a7dfac723c521e168876909aa37ce588ac00000000"
+      "hex": "010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff1f01320e6d696e65642062792062636f696e0431d5f7bf080000000000000000ffffffff0200f2052a010000001976a91415f34e5cc7c4d7cc5a896611af8fb242847e003d88ac0000000000000000266a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf90120000000000000000000000000000000000000000000000000000000000000000000000000"
     }
   ]
 }

--- a/api-docs-slate/source/includes/_node.md
+++ b/api-docs-slate/source/includes/_node.md
@@ -11,7 +11,8 @@ Command                     |cURL method    | Description
 [`/tx/address/:address`](#get-tx-by-address)              | `GET`   | TX by address
 [`/coin/:hash/:index`](#get-coin-by-outpoint)             | `GET`   | UTXO by txid and index
 [`/block/:block`](#get-block-by-hash-or-height)           | `GET`   | Block by hash or height
-[`/header/:header`](#get-block-header-by-hash-or-height)  | `GET`   | Block header by hash or height
+[`/header/:block`](#get-block-header-by-hash-or-height)   | `GET`   | Block header by hash or height
+[`/filter/:block`](#get-block-filter-by-hash-or-height)   | `GET`   | BIP158 block filter by hash or height
 [`/mempool`](#get-mempool-snapshot)                       | `GET`   | Mempool snapshot
 [`/broadcast`](#broadcast-transaction)                    | `POST`  | Broadcast TX
 [`/fee`](#estimate-fee)                                   | `GET`   | Estimate fee
@@ -328,6 +329,70 @@ Returns block header by block hash or height.
 
 ### HTTP Request
 `GET /header/:blockhashOrHeight`
+
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+:blockhashOrHeight | Hash or Height of block
+
+
+## Get block filter by hash or height
+
+```javascript
+let blockHash, blockHeight;
+```
+
+```shell--vars
+blockHash='6f1003edd05cad861395225415160b5236968cc223fe982796b6e959c9651d44';
+blockHeight='100';
+```
+
+```shell--curl
+curl $url/filter/$blockHash # by hash
+curl $url/filter/$blockHeight # by height
+```
+
+```shell--cli
+bcoin-cli filter $blockHash # by hash
+bcoin-cli filter $blockHeight # by height
+```
+
+```javascript
+const {NodeClient} = require('bclient');
+const {Network} = require('bcoin');
+const network = Network.get('regtest');
+
+const clientOptions = {
+  network: network.type,
+  port: network.rpcPort,
+  apiKey: 'api-key'
+}
+
+const client = new NodeClient(clientOptions);
+
+(async () => {
+  const filterByHeight = await client.getFilter(blockHeight);
+  const filterByHash = await client.getFilter(blockHash);
+  console.log("By height: \n", filterByHeight);
+  console.log("By hash: \n", filterByHash);
+})();
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "filter": "011ece10",
+  "header": "14940c1a3a7c764a1939300c386ceb378abfa581c243ad2c19bf7e0b52a09a09"
+}
+```
+
+Returns BIP158 block filter by block hash or height.
+
+### HTTP Request
+`GET /filter/:blockhashOrHeight`
 
 
 ### URL Parameters

--- a/api-docs-slate/source/includes/_node.md
+++ b/api-docs-slate/source/includes/_node.md
@@ -30,8 +30,7 @@ bcoin-cli info
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -123,8 +122,7 @@ bcoin-cli mempool
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -186,8 +184,7 @@ bcoin-cli block $blockHeight # by height
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -289,8 +286,7 @@ bcoin-cli header $blockHeight # by height
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -360,8 +356,7 @@ bcoin-cli filter $blockHeight # by height
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -423,8 +418,7 @@ bcoin-cli broadcast $tx
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -478,8 +472,7 @@ bcoin-cli fee $blocks
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -536,8 +529,7 @@ bcoin-cli reset $height
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {

--- a/api-docs-slate/source/includes/_node_rpc.md
+++ b/api-docs-slate/source/includes/_node_rpc.md
@@ -11,8 +11,7 @@ bcoin-cli rpc <method> <params>
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {

--- a/api-docs-slate/source/includes/_node_rpc_block.md
+++ b/api-docs-slate/source/includes/_node_rpc_block.md
@@ -13,8 +13,7 @@ bcoin-cli rpc getblockchaininfo
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -119,8 +118,7 @@ bcoin-cli rpc getbestblockhash
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -166,8 +164,7 @@ bcoin-cli rpc getblockcount
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -225,8 +222,7 @@ bcoin-cli rpc getblock $blockhash $verbose $details
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -307,8 +303,7 @@ bcoin-cli rpc getblockbyheight $blockheight $verbose $details
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -387,8 +382,7 @@ bcoin-cli rpc getblockhash $blockheight
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -445,8 +439,7 @@ bcoin-cli rpc getblockheader $blockhash $verbose
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -508,8 +501,7 @@ bcoin-cli rpc getchaintips
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -564,8 +556,7 @@ bcoin-cli rpc getdifficulty
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {

--- a/api-docs-slate/source/includes/_node_rpc_chain.md
+++ b/api-docs-slate/source/includes/_node_rpc_chain.md
@@ -16,8 +16,7 @@ bcoin-cli rpc pruneblockchain
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -74,8 +73,7 @@ bcoin-cli rpc invalidateblock $blockhash
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -130,8 +128,7 @@ bcoin-cli rpc reconsiderblock $blockhash
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {

--- a/api-docs-slate/source/includes/_node_rpc_general.md
+++ b/api-docs-slate/source/includes/_node_rpc_general.md
@@ -12,8 +12,7 @@ bcoin-cli rpc stop
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -58,8 +57,7 @@ bcoin-cli rpc getinfo
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -122,8 +120,7 @@ bcoin-cli rpc getmemoryinfo
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -179,8 +176,7 @@ bcoin-cli rpc setloglevel none
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -237,8 +233,7 @@ bcoin-cli rpc validateaddress $address
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -304,8 +299,7 @@ bcoin-cli rpc createmultisig $nrequired '[ "'$pubkey0'", "'$pubkey1'", "'$pubkey
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -365,8 +359,7 @@ bcoin-cli rpc createwitnessaddress $script
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -426,8 +419,7 @@ bcoin-cli rpc signmessagewithprivkey $privkey $message
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -487,8 +479,7 @@ bcoin-cli rpc verifymessage $address $signature "$message"
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -546,8 +537,7 @@ bcoin-cli rpc setmocktime $timestamp
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {

--- a/api-docs-slate/source/includes/_node_rpc_general.md
+++ b/api-docs-slate/source/includes/_node_rpc_general.md
@@ -78,13 +78,13 @@ const client = new NodeClient(clientOptions);
 
 ```json
 {
-  "version": "v1.0.0-pre",
+  "version": "2.0.0-dev",
   "protocolversion": 70015,
   "walletversion": 0,
   "balance": 0,
-  "blocks": 205,
+  "blocks": 533,
   "timeoffset": 0,
-  "connections": 3,
+  "connections": 0,
   "proxy": "",
   "difficulty": 4.6565423739069247e-10,
   "testnet": true,
@@ -216,7 +216,7 @@ let address;
 ```
 
 ```shell--vars
-address='RQKEexR9ZufYP6AKbwhzdv8iuiMFDh4sNZ';
+address='mhX1xHbKGzw3r8FoN5bUkmRixHPEDNywxh"';
 ```
 
 ```shell--curl
@@ -255,10 +255,10 @@ const client = new NodeClient(clientOptions);
 ```json
 {
   "isvalid": true,
-  "address": "RQKEexR9ZufYP6AKbwhzdv8iuiMFDh4sNZ",
-  "scriptPubKey": "76a914a4ecde9642f8070241451c5851431be9b658a7fe88ac",
-  "ismine": false,
-  "iswatchonly": false
+  "address": "mhX1xHbKGzw3r8FoN5bUkmRixHPEDNywxh",
+  "scriptPubKey": "76a91415f34e5cc7c4d7cc5a896611af8fb242847e003d88ac",
+  "isscript": false,
+  "iswitness": false
 }
 ```
 
@@ -320,7 +320,7 @@ const client = new NodeClient(clientOptions);
 
 ```json
 {
-  "address": "GfNqJAAyrCLr2bVHxn8wjMMYMh1EBPzUNk",
+  "address": "2NEn8sKGW2hZHF5Wyq4mJMAMqoPiGUMf3PB",
   "redeemScript": "522102e3d6bb36b0261628101ee67abd89d678522dc1199912512f814e70803652f39521034bc2280e68d3bdd0ef0664e0ad2949a467344d8e59e435fe2d9be81e39f70f762103d7ded41bb871936bf4d411371b25d706c572f28ef8d2613b45392e9f9c4348a553ae"
 }
 ```
@@ -380,7 +380,7 @@ const client = new NodeClient(clientOptions);
 
 ```json
 {
-  "address": "rb1qlfgqame3n0dt2ldjl2m9qjg6n2vut26jw3ezm25hqx9ez4m9wp5qjres8a",
+  "address": "bcrt1qlfgqame3n0dt2ldjl2m9qjg6n2vut26jw3ezm25hqx9ez4m9wp5qer5sas",
   "witnessScript": "0020fa500eef319bdab57db2fab650491a9a99c5ab5274722daa97018b9157657068"
 }
 ```
@@ -401,7 +401,7 @@ let privkey, message;
 ```
 
 ```shell--vars
-privkey='EMyedBwL5mb476uhWZ2wzEsSpu8kZwYgYaw5rGbjJh1kRjXF3M2d';
+privkey='cNmBeL4kpjLtNZcvjSezftq4ks6ajzZRi1z2AGpuBGy6XjxzytiQ';
 message='hello';
 ```
 
@@ -439,7 +439,7 @@ const client = new NodeClient(clientOptions);
 > The above command returns JSON "result" like this:
 
 ```json
-"MEUCIQCGLPYuLuSU1XQ7ctRvRzrY4M0dKAxShzEN3fwVoelGvgIgPmQ2RcRpeu0o68YsN42yzykI9VfTPooWHMvsFbIFEkg="
+"MEUCIQCsjaPbo1jOWBFdFGfmQnfQEdmRQP3vTi/wY2gbhxkEKgIgeZIm9+bMqZsiK4Ry5w3IgWycrcmKTzmuBtcvVCEguOM="
 ```
 
 
@@ -460,8 +460,8 @@ let address, signature, message;
 ```
 
 ```shell--vars
-address='RGCudRpNcn299Ja1EaVzgpnPD3YJgfMMiB';
-signature='MEUCIQCGLPYuLuSU1XQ7ctRvRzrY4M0dKAxShzEN3fwVoelGvgIgPmQ2RcRpeu0o68YsN42yzykI9VfTPooWHMvsFbIFEkg=';
+address='mhX1xHbKGzw3r8FoN5bUkmRixHPEDNywxh';
+signature='MEUCIQCsjaPbo1jOWBFdFGfmQnfQEdmRQP3vTi/wY2gbhxkEKgIgeZIm9+bMqZsiK4Ry5w3IgWycrcmKTzmuBtcvVCEguOM=';
 message='hello';
 ```
 

--- a/api-docs-slate/source/includes/_node_rpc_mempool.md
+++ b/api-docs-slate/source/includes/_node_rpc_mempool.md
@@ -15,8 +15,7 @@ bcoin-cli rpc getmempoolinfo
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -79,8 +78,7 @@ bcoin-cli rpc getmempoolancestors $txhash $verbose
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -186,8 +184,7 @@ bcoin-cli rpc getmempooldescendants $txhash $verbose
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -290,8 +287,7 @@ bcoin-cli rpc getmempoolentry $txhash
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -364,8 +360,7 @@ bcoin-cli rpc getrawmempool $verbose
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -460,8 +455,7 @@ bcoin-cli rpc prioritisetransaction $txhash $priorityDelta $feeDelta
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -522,8 +516,7 @@ bcoin-cli rpc estimatefee $nblocks
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -579,8 +572,7 @@ bcoin-cli rpc estimatepriority $nblocks
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -636,8 +628,7 @@ bcoin-cli rpc estimatesmartfee $nblocks
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -696,8 +687,7 @@ bcoin-cli rpc estimatesmartpriority $nblocks
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {

--- a/api-docs-slate/source/includes/_node_rpc_mining.md
+++ b/api-docs-slate/source/includes/_node_rpc_mining.md
@@ -631,7 +631,7 @@ let numblocks, address;
 
 ```shell--vars
 numblocks=2;
-address='RTZJdYScA7uGb5pbQPEczpDmq9HiYLv2fJ';
+address='mhX1xHbKGzw3r8FoN5bUkmRixHPEDNywxh';
 ```
 
 ```shell--curl
@@ -645,7 +645,6 @@ curl $url \
 ```
 
 ```shell--cli
-# Timeout error
 bcoin-cli rpc generatetoaddress $numblocks $address
 ```
 

--- a/api-docs-slate/source/includes/_node_rpc_mining.md
+++ b/api-docs-slate/source/includes/_node_rpc_mining.md
@@ -27,8 +27,7 @@ bcoin-cli rpc getnetworkhashps $blocks $height
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -77,8 +76,7 @@ bcoin-cli rpc getmininginfo
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -143,8 +141,7 @@ bcoin-cli rpc getwork
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -203,8 +200,7 @@ bcoin-cli rpc getworklp
 // Because there is a request timeout set on CLI http requests.
 // without manually adjusting the timeout (or receiving a new transaction on the current
 // network) this call will timeout before the request is complete.
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -259,8 +255,7 @@ bcoin-cli rpc getblocktemplate
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -381,8 +376,7 @@ bcoin-cli rpc submitblock $blockdata
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -431,8 +425,7 @@ bcoin-cli rpc verifyblock $blockdata
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -486,8 +479,7 @@ bcoin-cli rpc setgenerate $mining $proclimit
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -536,8 +528,7 @@ bcoin-cli rpc getgenerate
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -593,8 +584,7 @@ bcoin-cli rpc generate $numblocks
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -660,8 +650,7 @@ bcoin-cli rpc generatetoaddress $numblocks $address
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {

--- a/api-docs-slate/source/includes/_node_rpc_network.md
+++ b/api-docs-slate/source/includes/_node_rpc_network.md
@@ -132,26 +132,25 @@ const client = new NodeClient(clientOptions);
 ```json
 [
   {
-    "id": 65,
-    "addr": "127.0.0.1:48444",
-    "addrlocal": "127.0.0.1:42930",
-    "name": "localhost",
-    "services": "00000009",
+    "id": 17,
+    "addr": "67.210.228.203:8333",
+    "addrlocal": "100.200.50.10:52342",
+    "services": "0000000d",
     "relaytxes": true,
-    "lastsend": 1527116003,
-    "lastrecv": 1527116003,
-    "bytessent": 20734,
-    "bytesrecv": 19905,
-    "conntime": 348,
+    "lastsend": 1571762943,
+    "lastrecv": 1571762941,
+    "bytessent": 299812,
+    "bytesrecv": 1149318,
+    "conntime": 2534,
     "timeoffset": 0,
-    "pingtime": 0.001,
-    "minping": 0,
+    "pingtime": 0.054,
+    "minping": 0.051,
     "version": 70015,
-    "subver": "/bcoin:v1.0.0-pre/",
+    "subver": "/Satoshi:0.14.2/",
     "inbound": false,
-    "startingheight": 5456,
-    "besthash": "43bc66d363025c8953d0920d0bdd5d78e88905687dc0321053ce8f4c6ca0319d",
-    "bestheight": 5470,
+    "startingheight": 600551,
+    "besthash": "0000000000000000000425601a59d69922cdce6bad287950004d8308428b0748",
+    "bestheight": 600558,
     "banscore": 0,
     "inflight": [],
     "whitelisted": false
@@ -449,22 +448,26 @@ const client = new NodeClient(clientOptions);
 > The above command returns JSON "result" like this:
 
 ```json
-{
-  "version": "v1.0.0-pre",
-  "subversion": "/bcoin:v1.0.0-pre/",
+
+  "version": "2.0.0-dev",
+  "subversion": "/bcoin:2.0.0-dev/",
   "protocolversion": 70015,
   "localservices": "00000009",
+  "localservicenames": [
+    "NETWORK",
+    "WITNESS"
+  ],
   "localrelay": true,
   "timeoffset": 0,
   "networkactive": true,
-  "connections": 2,
+  "connections": 8,
   "networks": [],
   "relayfee": 0.00001,
   "incrementalfee": 0,
   "localaddresses": [
     {
-      "address": "18.188.224.12",
-      "port": 48444,
+      "address": "200.100.50.10",
+      "port": 8333,
       "score": 3
     }
   ],

--- a/api-docs-slate/source/includes/_node_rpc_network.md
+++ b/api-docs-slate/source/includes/_node_rpc_network.md
@@ -16,8 +16,7 @@ bcoin-cli rpc getconnectioncount
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -63,8 +62,7 @@ bcoin-cli rpc ping
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -112,8 +110,7 @@ bcoin-cli rpc getpeerinfo
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -199,8 +196,7 @@ bcoin-cli rpc addnode $nodeAddr $cmd
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -265,8 +261,7 @@ bcoin-cli rpc disconnectnode $nodeAddr
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -322,8 +317,7 @@ bcoin-cli rpc getaddednodeinfo $nodeAddr
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -382,8 +376,7 @@ bcoin-cli rpc getnettotals
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -435,8 +428,7 @@ bcoin-cli rpc getnetworkinfo
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -514,8 +506,7 @@ bcoin-cli rpc setban $nodeAddr $cmd
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -570,8 +561,7 @@ bcoin-cli rpc listbanned
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -626,8 +616,7 @@ bcoin-cli rpc clearbanned
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {

--- a/api-docs-slate/source/includes/_node_rpc_tx.md
+++ b/api-docs-slate/source/includes/_node_rpc_tx.md
@@ -26,8 +26,7 @@ bcoin-cli rpc gettxout $txhash $index $includemempool
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -92,8 +91,7 @@ bcoin-cli rpc gettxoutsetinfo
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -158,8 +156,7 @@ bcoin-cli rpc getrawtransaction $txhash $verbose
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -216,8 +213,7 @@ bcoin-cli rpc decoderawtransaction $rawtx
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -323,8 +319,7 @@ bcoin-cli rpc decodescript $script
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -387,8 +382,7 @@ bcoin-cli rpc sendrawtransaction $rawtx
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -453,8 +447,7 @@ bcoin-cli rpc createrawtransaction \
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -546,8 +539,7 @@ bcoin-cli rpc signrawtransaction $rawtx \
 
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -624,8 +616,7 @@ bcoin-cli rpc gettxoutproof '[ "'$txid0'", "'$txid1'" ]'
 
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -683,8 +674,7 @@ bcoin-cli rpc verifytxoutproof $proof
 
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {

--- a/api-docs-slate/source/includes/_node_rpc_tx.md
+++ b/api-docs-slate/source/includes/_node_rpc_tx.md
@@ -7,7 +7,7 @@ let txhash, index, includemempool;
 ```
 
 ```shell--vars
-txhash='0e690d6655767c8b388e7403d13dc9ebe49b68e3bd46248c840544f9da87d1e8';
+txhash='1ddd325274274f8a2a62e96c3f3fd5f7ecbca4a3ba24c039692e3068edd904a7';
 index=0;
 includemempool=1;
 ```
@@ -47,16 +47,16 @@ const client = new NodeClient(clientOptions);
 
 ```json
 {
-  "bestblock": "0e11d85b2081b84e131ba6692371737e6bb2aa7bc6d16e92954ffb1f9ad762e5",
-  "confirmations": 0,
-  "value": 0.4,
+  "bestblock": "6070a949eb9dcc36c416fe52a499d4cf2c7ad699ddeb2e358a9063a452c72523",
+  "confirmations": 4,
+  "value": 0.00024823,
   "scriptPubKey": {
-    "asm": "OP_DUP OP_HASH160 fe7e0711287688b33b9a5c239336c4700db34e63 OP_EQUALVERIFY OP_CHECKSIG",
-    "hex": "76a914fe7e0711287688b33b9a5c239336c4700db34e6388ac",
+    "asm": "OP_DUP OP_HASH160 94fe559c42b11736d0cab28d550b8972ccfbef3d OP_EQUALVERIFY OP_CHECKSIG",
+    "hex": "76a91494fe559c42b11736d0cab28d550b8972ccfbef3d88ac",
     "type": "PUBKEYHASH",
     "reqSigs": 1,
     "addresses": [
-      "RYUpgnvLvfi5T7q3hGSVvFrUy14kt61FC1"
+      "mu6kyujE3JeyPZYHwdBdBVrv6V5ReWwz6a"
     ]
   },
   "version": 1,
@@ -261,7 +261,7 @@ const client = new NodeClient(clientOptions);
         "type": "PUBKEYHASH",
         "reqSigs": 1,
         "addresses": [
-          "RYUpgnvLvfi5T7q3hGSVvFrUy14kt61FC1"
+          "n4iauL838sLmADwTwfRkeejc4jCs8UJsTE"
         ]
       }
     },
@@ -274,7 +274,7 @@ const client = new NodeClient(clientOptions);
         "type": "PUBKEYHASH",
         "reqSigs": 1,
         "addresses": [
-          "RRHY3TejXvTh6B1V5auViS9jVUcNxAUcrj"
+          "mwXJFzrRk86NoH7uKytkSq2rbCkV9tgAgp"
         ]
       }
     }
@@ -344,9 +344,9 @@ const client = new NodeClient(clientOptions);
   "type": "PUBKEYHASH",
   "reqSigs": 1,
   "addresses": [
-    "RRHY3TejXvTh6B1V5auViS9jVUcNxAUcrj"
+    "mwXJFzrRk86NoH7uKytkSq2rbCkV9tgAgp"
   ],
-  "p2sh": "GYtKY86R5JdPqDGEa3meuhE1tz3f7M45uD"
+  "p2sh": "2N8Hd7HBwFoqq3hHvSLQ1XWEKLgkhVjxisY"
 }
 ```
 
@@ -424,7 +424,7 @@ let txhash, txindex, amount, address, data;
 txhash='0e690d6655767c8b388e7403d13dc9ebe49b68e3bd46248c840544f9da87d1e8';
 txindex=1;
 amount=48.99900000;
-address='RStiqGLWA3aSMrWDyJvur4287GQ81AtLh1';
+address='mhX1xHbKGzw3r8FoN5bUkmRixHPEDNywxh';
 data='';
 ```
 
@@ -510,7 +510,7 @@ txhash='0e690d6655767c8b388e7403d13dc9ebe49b68e3bd46248c840544f9da87d1e8';
 txindex=1;
 scriptPubKey='76a914af92ad98c7f77559f96430dfef2a6805b87b24f888ac';
 amount=48.99900000;
-privkey='ELvsQiH9X1kgmbzD1j4ESAJnN47whh8qZHVF8B9DpSpecKQDcfX6';
+privkey='cNmBeL4kpjLtNZcvjSezftq4ks6ajzZRi1z2AGpuBGy6XjxzytiQ';
 ```
 
 ```shell--curl

--- a/api-docs-slate/source/includes/_transaction.md
+++ b/api-docs-slate/source/includes/_transaction.md
@@ -16,7 +16,7 @@ let txhash;
 ```
 
 ```shell--vars
-txhash='4c7846a8ff8415945e96937dea27bdb3144c15d793648d725602784826052586';
+txhash='77a39583060aa3ff2a705d401fea0c07e77e95d66cc10b744dc95098cad1bee1';
 ```
 
 ```shell--curl
@@ -51,50 +51,55 @@ const client = new NodeClient(clientOptions);
 
 ```json
 {
-  "hash": "4c7846a8ff8415945e96937dea27bdb3144c15d793648d725602784826052586",
-  "witnessHash": "4c7846a8ff8415945e96937dea27bdb3144c15d793648d725602784826052586",
-  "fee": 4540,
-  "rate": 20088,
-  "mtime": 1527029380,
-  "height": -1,
-  "block": null,
-  "time": 0,
-  "index": -1,
+  "hash": "77a39583060aa3ff2a705d401fea0c07e77e95d66cc10b744dc95098cad1bee1",
+  "witnessHash": "130bd86dccf06142b6134c7c38997d8babc2104a94d7a84da021d587740ed1c8",
+  "fee": 1740,
+  "rate": 9942,
+  "mtime": 1571763474,
+  "height": 530,
+  "block": "34d0385c667319c5225c7f82e025681bae2fb5df28809cc7cf432b491125c83c",
+  "time": 1571760040,
+  "index": 8,
   "version": 1,
   "inputs": [
     {
       "prevout": {
-        "hash": "a88387ca68a67f7f74e91723de0069154b532bf024c0e4054e36ea2234251181",
-        "index": 0
+        "hash": "9d2330c36814d20ccdba1b6fc5153ed3b294cb34fa99fc8199552014250ea285",
+        "index": 3
       },
-      "script": "4830450221009fcb51c7b5956f4524490ee5f2c446faf29cc159f750d93455a9af393cd5b78d02201c3b8b0388dba8cfe3f5bef52a39e980be581d87e06433390f2b099df3855913012103cb25dc2929ea58675113e60f4c08d084904189ab44a9a142179684c6cdd8d46a",
-      "witness": "00",
+      "script": "",
+      "witness": "02473044022008765f15a62f283c06082dfea6a6f413eae4190dbbfd57efae1813432b66613e0220163b708d4e1ccd6a439da2d222f72e4231bdfd877fcdfb73ac85566e6358c559012103d2d0677a136821cb92361501570173e2c6b0d8b12e584737ffc991d2d1ccf026",
       "sequence": 4294967295,
       "coin": {
         "version": 1,
-        "height": 36,
-        "value": 5000000000,
-        "script": "76a91420a060fec9a7dfac723c521e168876909aa37ce588ac",
-        "address": "RCFhpyWXkz5GxskL96q4KtceRXuAMnWUQo",
-        "coinbase": true
+        "height": 528,
+        "value": 34297185559,
+        "script": "0014268a968f7d4d1d72bbecc0ebca21d890901ba312",
+        "address": "bcrt1qy69fdrmaf5wh9wlvcr4u5gwcjzgphgcjswyuvn",
+        "coinbase": false
       }
     }
   ],
   "outputs": [
     {
-      "value": 87654321,
-      "script": "76a914a4ecde9642f8070241451c5851431be9b658a7fe88ac",
-      "address": "RQKEexR9ZufYP6AKbwhzdv8iuiMFDh4sNZ"
+      "value": 37547,
+      "script": "00143ce6c756ef2f35d61aab99d1619aab2f48da6987",
+      "address": "bcrt1q8nnvw4h09u6avx4tn8gkrx4t9ayd56v86q7ceg"
     },
     {
-      "value": 4912341139,
-      "script": "76a9145bd075f5e3c5ff3e8467d94dee593d410967d93d88ac",
-      "address": "RHefJ5hLW9jyEwwdxhci6r7AH7SAxdpGW3"
+      "value": 50131,
+      "script": "76a914e53103ac18b5d274dcea14e6b0c856182ce7021688ac",
+      "address": "n2QokZQd8Fn6a82vwXtndYy88HeUk3BZio"
+    },
+    {
+      "value": 34297096141,
+      "script": "0014f0ddfca1c6023538c032f6fb46a35703099319fe",
+      "address": "bcrt1q7rwlegwxqg6n3spj7ma5dg6hqvyexx07zmt40j"
     }
   ],
   "locktime": 0,
-  "hex": "01000000018111253422ea364e05e4c024f02b534b156900de2317e9747f7fa668ca8783a8000000006b4830450221009fcb51c7b5956f4524490ee5f2c446faf29cc159f750d93455a9af393cd5b78d02201c3b8b0388dba8cfe3f5bef52a39e980be581d87e06433390f2b099df3855913012103cb25dc2929ea58675113e60f4c08d084904189ab44a9a142179684c6cdd8d46affffffff02b17f3905000000001976a914a4ecde9642f8070241451c5851431be9b658a7fe88ac9360cc24010000001976a9145bd075f5e3c5ff3e8467d94dee593d410967d93d88ac00000000",
-  "confirmations": 207
+  "hex": "0100000000010185a20e251420559981fc99fa34cb94b2d33e15c56f1bbacd0cd21468c330239d0300000000ffffffff03ab920000000000001600143ce6c756ef2f35d61aab99d1619aab2f48da6987d3c30000000000001976a914e53103ac18b5d274dcea14e6b0c856182ce7021688accd2744fc07000000160014f0ddfca1c6023538c032f6fb46a35703099319fe02473044022008765f15a62f283c06082dfea6a6f413eae4190dbbfd57efae1813432b66613e0220163b708d4e1ccd6a439da2d222f72e4231bdfd877fcdfb73ac85566e6358c559012103d2d0677a136821cb92361501570173e2c6b0d8b12e584737ffc991d2d1ccf02600000000",
+  "confirmations": 6
 }
 ```
 
@@ -121,7 +126,7 @@ let address;
 ```
 
 ```shell--vars
-address='RHefJ5hLW9jyEwwdxhci6r7AH7SAxdpGW3';
+address='bcrt1q8nnvw4h09u6avx4tn8gkrx4t9ayd56v86q7ceg';
 ```
 
 ```shell--curl
@@ -157,51 +162,56 @@ const client = new NodeClient(clientOptions);
 ```json
 [
   {
-    "hash": "4c7846a8ff8415945e96937dea27bdb3144c15d793648d725602784826052586",
-    "witnessHash": "4c7846a8ff8415945e96937dea27bdb3144c15d793648d725602784826052586",
-    "fee": 4540,
-    "rate": 20088,
-    "mtime": 1527029380,
-    "height": -1,
-    "block": null,
-    "time": 0,
-    "index": -1,
+    "hash": "77a39583060aa3ff2a705d401fea0c07e77e95d66cc10b744dc95098cad1bee1",
+    "witnessHash": "130bd86dccf06142b6134c7c38997d8babc2104a94d7a84da021d587740ed1c8",
+    "fee": 1740,
+    "rate": 9942,
+    "mtime": 1571763513,
+    "height": 530,
+    "block": "34d0385c667319c5225c7f82e025681bae2fb5df28809cc7cf432b491125c83c",
+    "time": 1571760040,
+    "index": 8,
     "version": 1,
     "inputs": [
       {
         "prevout": {
-          "hash": "a88387ca68a67f7f74e91723de0069154b532bf024c0e4054e36ea2234251181",
-          "index": 0
+          "hash": "9d2330c36814d20ccdba1b6fc5153ed3b294cb34fa99fc8199552014250ea285",
+          "index": 3
         },
-        "script": "4830450221009fcb51c7b5956f4524490ee5f2c446faf29cc159f750d93455a9af393cd5b78d02201c3b8b0388dba8cfe3f5bef52a39e980be581d87e06433390f2b099df3855913012103cb25dc2929ea58675113e60f4c08d084904189ab44a9a142179684c6cdd8d46a",
-        "witness": "00",
+        "script": "",
+        "witness": "02473044022008765f15a62f283c06082dfea6a6f413eae4190dbbfd57efae1813432b66613e0220163b708d4e1ccd6a439da2d222f72e4231bdfd877fcdfb73ac85566e6358c559012103d2d0677a136821cb92361501570173e2c6b0d8b12e584737ffc991d2d1ccf026",
         "sequence": 4294967295,
         "coin": {
           "version": 1,
-          "height": 36,
-          "value": 5000000000,
-          "script": "76a91420a060fec9a7dfac723c521e168876909aa37ce588ac",
-          "address": "RCFhpyWXkz5GxskL96q4KtceRXuAMnWUQo",
-          "coinbase": true
+          "height": 528,
+          "value": 34297185559,
+          "script": "0014268a968f7d4d1d72bbecc0ebca21d890901ba312",
+          "address": "bcrt1qy69fdrmaf5wh9wlvcr4u5gwcjzgphgcjswyuvn",
+          "coinbase": false
         }
       }
     ],
     "outputs": [
       {
-        "value": 87654321,
-        "script": "76a914a4ecde9642f8070241451c5851431be9b658a7fe88ac",
-        "address": "RQKEexR9ZufYP6AKbwhzdv8iuiMFDh4sNZ"
+        "value": 37547,
+        "script": "00143ce6c756ef2f35d61aab99d1619aab2f48da6987",
+        "address": "bcrt1q8nnvw4h09u6avx4tn8gkrx4t9ayd56v86q7ceg"
       },
       {
-        "value": 4912341139,
-        "script": "76a9145bd075f5e3c5ff3e8467d94dee593d410967d93d88ac",
-        "address": "RHefJ5hLW9jyEwwdxhci6r7AH7SAxdpGW3"
+        "value": 50131,
+        "script": "76a914e53103ac18b5d274dcea14e6b0c856182ce7021688ac",
+        "address": "n2QokZQd8Fn6a82vwXtndYy88HeUk3BZio"
+      },
+      {
+        "value": 34297096141,
+        "script": "0014f0ddfca1c6023538c032f6fb46a35703099319fe",
+        "address": "bcrt1q7rwlegwxqg6n3spj7ma5dg6hqvyexx07zmt40j"
       }
     ],
     "locktime": 0,
-    "hex": "01000000018111253422ea364e05e4c024f02b534b156900de2317e9747f7fa668ca8783a8000000006b4830450221009fcb51c7b5956f4524490ee5f2c446faf29cc159f750d93455a9af393cd5b78d02201c3b8b0388dba8cfe3f5bef52a39e980be581d87e06433390f2b099df3855913012103cb25dc2929ea58675113e60f4c08d084904189ab44a9a142179684c6cdd8d46affffffff02b17f3905000000001976a914a4ecde9642f8070241451c5851431be9b658a7fe88ac9360cc24010000001976a9145bd075f5e3c5ff3e8467d94dee593d410967d93d88ac00000000",
-    "confirmations": 207
-  }
+    "hex": "0100000000010185a20e251420559981fc99fa34cb94b2d33e15c56f1bbacd0cd21468c330239d0300000000ffffffff03ab920000000000001600143ce6c756ef2f35d61aab99d1619aab2f48da6987d3c30000000000001976a914e53103ac18b5d274dcea14e6b0c856182ce7021688accd2744fc07000000160014f0ddfca1c6023538c032f6fb46a35703099319fe02473044022008765f15a62f283c06082dfea6a6f413eae4190dbbfd57efae1813432b66613e0220163b708d4e1ccd6a439da2d222f72e4231bdfd877fcdfb73ac85566e6358c559012103d2d0677a136821cb92361501570173e2c6b0d8b12e584737ffc991d2d1ccf02600000000",
+    "confirmations": 6
+  },
   ...
 ]
 ```

--- a/api-docs-slate/source/includes/_transaction.md
+++ b/api-docs-slate/source/includes/_transaction.md
@@ -28,8 +28,7 @@ bcoin-cli tx $txhash
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {
@@ -134,8 +133,7 @@ bcoin-cli tx $address
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const clientOptions = {

--- a/api-docs-slate/source/includes/_wallet.md
+++ b/api-docs-slate/source/includes/_wallet.md
@@ -243,7 +243,7 @@ id='newWallet'
 passphrase='secret456'
 witness=false
 watchOnly=true
-accountKey='rpubKBAoFrCN1HzSEDye7jcQaycA8L7MjFGmJD1uuvUZ21d9srAmAxmB7o1tCZRyXmTRuy5ZDQDV6uxtcxfHAadNFtdK7J6RV9QTcHTCEoY5FtQD'
+accountKey='tpubDDF921KoqbemP3yPiBMBzvkDY5pe4KpirJtXtSaTdRkZ3LyqorrHy1mv1XLNqrmTQQXztdTQiZxDtPxGZ9Lmiqtv8wJYJs5o52J54djLpqC'
 ```
 
 ```shell--curl
@@ -253,7 +253,7 @@ curl $walleturl/$id \
 ```
 
 ```shell--cli
-# watchOnly defaults to true if --key flag is set
+# watch-only defaults to true if --account-key flag is set
 
 bwallet-cli mkwallet $id --witness=$witness --passphrase=$passphrase --watch-only=$watchOnly --account-key=$accountKey
 ```
@@ -288,16 +288,16 @@ const options = {
 ```json
 {
   "network": "regtest",
-  "wid": 2,
+  "wid": 11,
   "id": "newWallet",
   "watchOnly": true,
   "accountDepth": 1,
-  "token": "21b728d8f9e4d909349cf0c8f1e4e74fd45b180103cb7f1885a197d04012ba08",
+  "token": "489d43e398dad34e69653e5edb5cb39b6d55be3364753c07d084d4b3d0292af7",
   "tokenDepth": 0,
   "master": {
     "encrypted": true,
-    "until": 1527181467,
-    "iv": "53effaf192a346b40b08a52dac0658ce",
+    "until": 1571763677,
+    "iv": "4e24f2a5908e20da0b8ba3e88dcda272",
     "algorithm": "pbkdf2",
     "n": 50000,
     "r": 0,
@@ -521,14 +521,13 @@ const wallet = walletClient.wallet(id);
 {
   "encrypted": false,
   "key": {
-    "xprivkey": "tprv8ZgxMBicQKsPe7977psQCjBBjWtLDoJVPiiKog42RCoShJLJATYeSkNTzdwfgpkcqwrPYAmRCeudd6kkVWrs2kH5fnTaxrHhi1TfvgxJsZD",
-    "mnemonic": {
-      "bits": 128,
-      "language": "english",
-      "entropy": "a560ac7eb5c2ed412a4ba0790f73449d",
-      "phrase": "pistol air cabbage high conduct party powder inject jungle knee spell derive",
-      "passphrase": ""
-    }
+    "xprivkey": "tprv8ZgxMBicQKsPfNKy1Wf9EV1cTmz1Cmm6MVrvYdgcR6Hf8sEDUAzhnnoiVbw5jejp4EZWXynQEJhB62oSfANpHRAJqfiZarh1gVMowcJZ2Mn"
+  },
+  "mnemonic": {
+    "bits": 128,
+    "language": "english",
+    "entropy": "e35833c318d677945ec21efff032bb64",
+    "phrase": "today screen valid coyote guess sketch kitchen duck zoo light put siege"
   }
 }
 ```
@@ -632,7 +631,7 @@ id="primary"
 passphrase="secret123"
 rate=0.00001000
 value=0.00020000
-address="RPipJ9yeeQxHn6YcBXd9WPy2V6cezzAuY8"
+address="mo2L7KZgmH2QNs9QCBAFwQPqBJNSXNhQWV"
 
 bwallet-cli send --id=$id --value=$value --address=$address ---passphrase=$passphrase
 ```
@@ -642,7 +641,7 @@ id="primary"
 passphrase="secret123"
 rate=1000
 value=20000
-address="RPipJ9yeeQxHn6YcBXd9WPy2V6cezzAuY8"
+address="mo2L7KZgmH2QNs9QCBAFwQPqBJNSXNhQWV"
 
 curl $walleturl/$id/send \
   -X POST \
@@ -661,7 +660,7 @@ id="primary"
 passphrase="secret123"
 rate=1000
 value=20000
-address="RPipJ9yeeQxHn6YcBXd9WPy2V6cezzAuY8"
+address="mo2L7KZgmH2QNs9QCBAFwQPqBJNSXNhQWV"
 
 const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
@@ -691,13 +690,13 @@ const options = {
 
 ```json
 {
-  "hash": "8fafdf2a6c44fc48dbe01147339a59fa11f2c5a7254d2e6df27ce0a61df29cf7",
+  "hash": "4d44a0285e4e5ae782fc9dee32d2a7b60ec63009a731d72e51374910582f517c",
   "height": -1,
   "block": null,
   "time": 0,
-  "mtime": 1527181979,
+  "mtime": 1571764348,
   "date": "1970-01-01T00:00:00Z",
-  "mdate": "2018-05-24T17:12:59Z",
+  "mdate": "2019-10-22T17:12:28Z",
   "size": 225,
   "virtualSize": 225,
   "fee": 4540,
@@ -705,34 +704,39 @@ const options = {
   "confirmations": 0,
   "inputs": [
     {
-      "value": 5000000000,
-      "address": "R9cS4kuYVWHaDJmRGMpwx7zCNjw97Zm5LL",
+      "value": 2500000000,
+      "address": "mhX1xHbKGzw3r8FoN5bUkmRixHPEDNywxh",
       "path": {
         "name": "default",
         "account": 0,
         "change": false,
-        "derivation": "m/0'/0/0"
+        "derivation": "m/0'/0/1"
       }
     }
   ],
   "outputs": [
     {
-      "value": 1000,
-      "address": "RPipJ9yeeQxHn6YcBXd9WPy2V6cezzAuY8",
-      "path": null
-    },
-    {
-      "value": 4999994460,
-      "address": "RX3ZPBURVYzjRPR3wYdGepMBa26CGK8VMu",
+      "value": 20000,
+      "address": "mo2L7KZgmH2QNs9QCBAFwQPqBJNSXNhQWV",
       "path": {
         "name": "default",
         "account": 0,
         "change": true,
         "derivation": "m/0'/1/0"
       }
+    },
+    {
+      "value": 2499975460,
+      "address": "mhpSYq8bnM5XJVbpafdLNUtLZefr2d6xSq",
+      "path": {
+        "name": "default",
+        "account": 0,
+        "change": true,
+        "derivation": "m/0'/1/1"
+      }
     }
   ],
-  "tx": "01000000017a2c5144386ed317c1f2ff484e7e11be718721d7ddab15773d0dd6133fb38a14000000006a4730440220710c42d68bd02789c31e7d351a6795c2a9386749e1d8a6aa61d46d5ba345843e022023d83a31e657f043d08d7e86379b818c98d788bb34bfe71ad2d9fa6dcb44b48b0121036b90b9f76925944b238239115f0c12ecee1b7e060e50850b4884aa0e0daea0c4ffffffff02e8030000000000001976a9149e6a64a9dfdf49bfa72e1402663ac40aa5e30a7188ac5cdc052a010000001976a914eebeba5a5b40bb11ca70f48b71bdb2c2b89f0c5c88ac00000000"
+  "tx": "010000000195c60f9cdf95961f696a83bac71adcab286b4a269bb5bdae71ca95d634fab681000000006a473044022068d00d638a3b4d4d54c76167fff1bad023f34375d3bb05a7cb0c051ac63133ed0220182eba4cd68d27c43c071d6690a60c8b13f4c775fec145a736f6f58781fa2d5a01210336c99e45e00b73c863497a989fe6feb08439ca2d7cf98f55bc261ed70ed28a7bffffffff02204e0000000000001976a91452572750e3cf71b97a58dd084f34c3b7027ec75288ac24990295000000001976a914193ee8a7e5d7d5c299785dea90802bc1906a893788ac00000000"
 }
 ```
 
@@ -768,40 +772,40 @@ address <br> _string_ | destination address for transaction
 
 ## Create a Transaction
 ```shell--cli
-id="multisig1"
-passphrase="multisecret123"
+id="multisig-watch"
 rate=0.00001000
 value=0.05000000
-address="RPipJ9yeeQxHn6YcBXd9WPy2V6cezzAuY8"
+address="mg54SV2ZubNQ5urTbd42mUsQ54byPvSg5j"
+sign=false
 
-bwallet-cli mktx --id=$id --value=$value --address=$address ---passphrase=$passphrase
+bwallet-cli mktx --id=$id --rate=$rate --value=$value --address=$address ---passphrase=$passphrase --sign=$sign
 ```
 
 ```shell--curl
 id="multisig1"
-passphrase="multisecret123"
 rate=1000
 value=5000000
-address="RPipJ9yeeQxHn6YcBXd9WPy2V6cezzAuY8"
+address="mg54SV2ZubNQ5urTbd42mUsQ54byPvSg5"
+sign=false
 
 curl $walleturl/$id/create \
   -X POST \
   --data '{
-    "passphrase":"'$passphrase'",
     "rate":'$rate',
     "outputs":[
       {"address":"'$address'", "value":'$value'}
-    ]
+    ],
+    "sign": '$false'
   }'
 ```
 
 ```javascript
-let id, passphrase, rate, value, address;
-id="multisig1"
-passphrase="multisecret123"
+let id, rate, value, address, sign;
+id="multisig-watch"
 rate=1000
 value=5000000
-address="RPipJ9yeeQxHn6YcBXd9WPy2V6cezzAuY8"
+address="mg54SV2ZubNQ5urTbd42mUsQ54byPvSg5"
+sign=false
 
 const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
@@ -816,9 +820,9 @@ const walletClient = new WalletClient(walletOptions);
 const wallet = walletClient.wallet(id);
 
 const options = {
-  passphrase: passphrase,
   rate: rate,
-  outputs: [{ value: value, address: address }]
+  outputs: [{ value: value, address: address }],
+  sign: sign
 };
 
 (async () => {
@@ -831,45 +835,45 @@ const options = {
 
 ```json
 {
-  "hash": "2c550d94e3de0de48d82199442aec45bbc75e253eaf67c953db4265691cc60ec",
-  "witnessHash": "2c550d94e3de0de48d82199442aec45bbc75e253eaf67c953db4265691cc60ec",
-  "fee": 6800,
-  "rate": 25855,
-  "mtime": 1527182869,
+  "hash": "3f61cbbe01ca9eb7eb0fb8c37f15e92d2fee8c28ea54fef5b7bc89eee219074b",
+  "witnessHash": "3f61cbbe01ca9eb7eb0fb8c37f15e92d2fee8c28ea54fef5b7bc89eee219074b",
+  "fee": 3840,
+  "rate": 30000,
+  "mtime": 1571766790,
   "version": 1,
   "inputs": [
     {
       "prevout": {
-        "hash": "31ebd87739a0e58098d127d76ee80ebfd8b5d923a8fcaf2d0908c16f123043be",
+        "hash": "4e6c7db14b22e39ca800b0eb83d698619849ac3245408cf03ae5dc752e2d884c",
         "index": 0
       },
-      "script": "0000473044022064ac064f8b0e224413cf7e7c3aa2758013dd0cff6b421a273fb6f870894b200f022064da80d0ea08110b1c18817a66b1e576f945f73256407175b0fcc9936644b3320147522102fac079263a41252f1602406313cc26caf76029135fda4f2423b997b6c89ce78f210304ea9eddb0c0fe241c89ceb2ee8b15870ede2757dfbd42fee60ba9f63d91290652ae",
+      "script": "",
       "witness": "00",
       "sequence": 4294967295,
       "coin": {
         "version": 1,
-        "height": -1,
-        "value": 10000000,
-        "script": "a9143ddf94d382bc20b256748e0ab20b040efc07344c87",
-        "address": "GPV5UXtx3Zbb7CGL7k31kykXkbNUxM6hXW",
-        "coinbase": false
+        "height": 746,
+        "value": 312500000,
+        "script": "00201e669358ab0b70bbdf63ac7abc442ee1b1f6f0fe24b1d67b2e3527ffac664c39",
+        "address": "bcrt1qrenfxk9tpdcthhmr43atc3pwuxcldu87yjcav7ewx5nlltrxfsustr8wj5",
+        "coinbase": true
       }
     }
   ],
   "outputs": [
     {
-      "value": 4993200,
-      "script": "a9144ff1a73bf41d28a8a60e057a5c4bb0a38c0bbaf887",
-      "address": "GR8dHeLMn8CPVAztoEjkAxHS6eWSgf6Hcr"
+      "value": 5000000,
+      "script": "76a914061270cea3bdd77a5442657d177f4490642e7a2288ac",
+      "address": "mg54SV2ZubNQ5urTbd42mUsQ54byPvSg5j"
     },
     {
-      "value": 5000000,
-      "script": "76a9149e6a64a9dfdf49bfa72e1402663ac40aa5e30a7188ac",
-      "address": "RPipJ9yeeQxHn6YcBXd9WPy2V6cezzAuY8"
+      "value": 307496160,
+      "script": "0020485f95ef73a1f444cbbfdb7ff1f43c7e34c069d25a823026d3513cfa64cfd677",
+      "address": "bcrt1qfp0etmmn586yfjalmdllrapu0c6vq6wjt2prqfkn2y705ex06ems39f93c"
     }
   ],
   "locktime": 0,
-  "hex": "0100000001be4330126fc108092daffca823d9b5d8bf0ee86ed727d19880e5a03977d8eb3100000000920000473044022064ac064f8b0e224413cf7e7c3aa2758013dd0cff6b421a273fb6f870894b200f022064da80d0ea08110b1c18817a66b1e576f945f73256407175b0fcc9936644b3320147522102fac079263a41252f1602406313cc26caf76029135fda4f2423b997b6c89ce78f210304ea9eddb0c0fe241c89ceb2ee8b15870ede2757dfbd42fee60ba9f63d91290652aeffffffff02b0304c000000000017a9144ff1a73bf41d28a8a60e057a5c4bb0a38c0bbaf887404b4c00000000001976a9149e6a64a9dfdf49bfa72e1402663ac40aa5e30a7188ac00000000"
+  "hex": "01000000014c882d2e75dce53af08c404532ac49986198d683ebb000a89ce3224bb17d6c4e0000000000ffffffff02404b4c00000000001976a914061270cea3bdd77a5442657d177f4490642e7a2288ace004541200000000220020485f95ef73a1f444cbbfdb7ff1f43c7e34c069d25a823026d3513cfa64cfd67700000000"
 }
 ```
 
@@ -900,6 +904,7 @@ selection <br> _enum_ - `all`, `random`, `age`, `value`| How to select coins
 depth <br> _int_  | number of confirmation for coins to spend
 value <br> _int_ (or _float_) | Value to send in satoshis (or whole BTC, see warning above)
 address <br> _string_ | destination address for transaction
+sign <br> _bool_ | whether to sign the TX (must be false for watch-only wallets)
 
 
 
@@ -909,9 +914,9 @@ let id, tx, passphrase;
 ```
 
 ```shell--vars
-id="multisig2"
-passphrase="multisecret456"
-tx="0100000001be4330126fc108092daffca823d9b5d8bf0ee86ed727d19880e5a03977d8eb3100000000920000473044022064ac064f8b0e224413cf7e7c3aa2758013dd0cff6b421a273fb6f870894b200f022064da80d0ea08110b1c18817a66b1e576f945f73256407175b0fcc9936644b3320147522102fac079263a41252f1602406313cc26caf76029135fda4f2423b997b6c89ce78f210304ea9eddb0c0fe241c89ceb2ee8b15870ede2757dfbd42fee60ba9f63d91290652aeffffffff02b0304c000000000017a9144ff1a73bf41d28a8a60e057a5c4bb0a38c0bbaf887404b4c00000000001976a9149e6a64a9dfdf49bfa72e1402663ac40aa5e30a7188ac00000000"
+id="multisig1"
+passphrase="multisecret123"
+tx="01000000014c882d2e75dce53af08c404532ac49986198d683ebb000a89ce3224bb17d6c4e0000000000ffffffff02404b4c00000000001976a914061270cea3bdd77a5442657d177f4490642e7a2288ace004541200000000220020485f95ef73a1f444cbbfdb7ff1f43c7e34c069d25a823026d3513cfa64cfd67700000000"
 ```
 
 ```shell--cli
@@ -949,45 +954,45 @@ const options = { tx: tx, passphrase: passphrase };
 
 ```json
 {
-  "hash": "a355e0fcfb727c8161f3b2e55e0cda40f4614ea38d4834f82460cfdc9941381a",
-  "witnessHash": "a355e0fcfb727c8161f3b2e55e0cda40f4614ea38d4834f82460cfdc9941381a",
-  "fee": 170,
-  "rate": 507,
-  "mtime": 1527183237,
+  "hash": "3f61cbbe01ca9eb7eb0fb8c37f15e92d2fee8c28ea54fef5b7bc89eee219074b",
+  "witnessHash": "68e9d7a28a571746eb7561ebc107479da26eb1cb2246ad5f05769149f6ec84db",
+  "fee": 3840,
+  "rate": 21942,
+  "mtime": 1571767276,
   "version": 1,
   "inputs": [
     {
       "prevout": {
-        "hash": "31ebd87739a0e58098d127d76ee80ebfd8b5d923a8fcaf2d0908c16f123043be",
+        "hash": "4e6c7db14b22e39ca800b0eb83d698619849ac3245408cf03ae5dc752e2d884c",
         "index": 0
       },
-      "script": "004730440220764ce5fa17f7d6fc8921a85ddd81e3378e88aae92a02ab8ff72646bb9d2ad3c102203075f1c8f97d48626ed22e86495c28c19386c1adb9160d84ab28fb5c7c65b103014830450221008bbc87270043e0c701cb4ba8bb7b0b8014f7bdac66fb8ae104bfe91e0469983f022003734c66e3c1f40293e90b2327fe509f68ada13c44b69bec364c01763a0699940147522102fac079263a41252f1602406313cc26caf76029135fda4f2423b997b6c89ce78f210304ea9eddb0c0fe241c89ceb2ee8b15870ede2757dfbd42fee60ba9f63d91290652ae",
-      "witness": "00",
+      "script": "",
+      "witness": "050000483045022100a8ba55fb5bdf6a69fc820d44c4430d55ae0356f7dd5cdcf5bb27e8cb24535fb802204a6a23dedc1acff4725e99b51bce9f2692aa08d6063842be51d5728e8f95f76f0100695221027b88633d65cb48667012bb64039afda0b50c51abb2fe11aca975b324b8f0f44c2102f9ae8660d9dc5f3d62a5c347e8cd431ecc9404c17ecbb57ab89aa54b6df68a422103001a9a61d4989e229cfa5bb9acf0fb03fa5f3f1c9785fc1de2d76a8f363c457953ae",
       "sequence": 4294967295,
       "coin": {
         "version": 1,
-        "height": -1,
-        "value": 10000000,
-        "script": "a9143ddf94d382bc20b256748e0ab20b040efc07344c87",
-        "address": "GPV5UXtx3Zbb7CGL7k31kykXkbNUxM6hXW",
-        "coinbase": false
+        "height": 746,
+        "value": 312500000,
+        "script": "00201e669358ab0b70bbdf63ac7abc442ee1b1f6f0fe24b1d67b2e3527ffac664c39",
+        "address": "bcrt1qrenfxk9tpdcthhmr43atc3pwuxcldu87yjcav7ewx5nlltrxfsustr8wj5",
+        "coinbase": true
       }
     }
   ],
   "outputs": [
     {
-      "value": 4999830,
-      "script": "a9144ff1a73bf41d28a8a60e057a5c4bb0a38c0bbaf887",
-      "address": "GR8dHeLMn8CPVAztoEjkAxHS6eWSgf6Hcr"
+      "value": 5000000,
+      "script": "76a914061270cea3bdd77a5442657d177f4490642e7a2288ac",
+      "address": "mg54SV2ZubNQ5urTbd42mUsQ54byPvSg5j"
     },
     {
-      "value": 5000000,
-      "script": "76a9149e6a64a9dfdf49bfa72e1402663ac40aa5e30a7188ac",
-      "address": "RPipJ9yeeQxHn6YcBXd9WPy2V6cezzAuY8"
+      "value": 307496160,
+      "script": "0020485f95ef73a1f444cbbfdb7ff1f43c7e34c069d25a823026d3513cfa64cfd677",
+      "address": "bcrt1qfp0etmmn586yfjalmdllrapu0c6vq6wjt2prqfkn2y705ex06ems39f93c"
     }
   ],
   "locktime": 0,
-  "hex": "0100000001be4330126fc108092daffca823d9b5d8bf0ee86ed727d19880e5a03977d8eb3100000000da004730440220764ce5fa17f7d6fc8921a85ddd81e3378e88aae92a02ab8ff72646bb9d2ad3c102203075f1c8f97d48626ed22e86495c28c19386c1adb9160d84ab28fb5c7c65b103014830450221008bbc87270043e0c701cb4ba8bb7b0b8014f7bdac66fb8ae104bfe91e0469983f022003734c66e3c1f40293e90b2327fe509f68ada13c44b69bec364c01763a0699940147522102fac079263a41252f1602406313cc26caf76029135fda4f2423b997b6c89ce78f210304ea9eddb0c0fe241c89ceb2ee8b15870ede2757dfbd42fee60ba9f63d91290652aeffffffff02964a4c000000000017a9144ff1a73bf41d28a8a60e057a5c4bb0a38c0bbaf887404b4c00000000001976a9149e6a64a9dfdf49bfa72e1402663ac40aa5e30a7188ac00000000"
+  "hex": "010000000001014c882d2e75dce53af08c404532ac49986198d683ebb000a89ce3224bb17d6c4e0000000000ffffffff02404b4c00000000001976a914061270cea3bdd77a5442657d177f4490642e7a2288ace004541200000000220020485f95ef73a1f444cbbfdb7ff1f43c7e34c069d25a823026d3513cfa64cfd677050000483045022100a8ba55fb5bdf6a69fc820d44c4430d55ae0356f7dd5cdcf5bb27e8cb24535fb802204a6a23dedc1acff4725e99b51bce9f2692aa08d6063842be51d5728e8f95f76f0100695221027b88633d65cb48667012bb64039afda0b50c51abb2fe11aca975b324b8f0f44c2102f9ae8660d9dc5f3d62a5c347e8cd431ecc9404c17ecbb57ab89aa54b6df68a422103001a9a61d4989e229cfa5bb9acf0fb03fa5f3f1c9785fc1de2d76a8f363c457953ae00000000"
 }
 ```
 
@@ -1212,8 +1217,8 @@ let id, account, key;
 id='primary'
 watchid='watchonly1'
 account='default'
-pubkey='0215a9110e2a9b293c332c28d69f88081aa2a949fde67e35a13fbe19410994ffd9'
-privkey='EMdDCvF1ZjsCnimTnTQfjw6x8CQmVidtJxKBegCVzPw3g6yRoDkK'
+pubkey='03b28be4fd749be06233452542e9d602f97a9b9c292aed4e4669c3fcc499e366de'
+privkey='cNRiqwzRfcUfokNV8nSnDKb3NsKPhfRV2z5kBN11GKFb3GXkk1Hj'
 ```
 
 ```shell--cli
@@ -1297,7 +1302,7 @@ let id, account, address;
 ```shell--vars
 id='watchonly1'
 account='default'
-address='RUkNXekA1QcDzNZhn2TqNavPUxmaosCzJC'
+address='msKYwEVXcKBxatPMfFLdVwYug6bz4YS87J'
 ```
 
 ```shell--cli
@@ -1472,7 +1477,7 @@ let id, key, account;
 ```shell--vars
 id="multisig3"
 account="default"
-key="rpubKBBGCWqgVn4RRVpJTDUvTJnFHYiQuoUNy7s6W57U36KJ3r5inJp7iVRJZHvkFjbgfaGVs9fkvcCQS5ZMmc7BYFCrkADgmGKDCsjYK1vGmoFw"
+key="tpubDDkzvYzn2iJLqucWgnULe1x3DR5PCaZvWzpg13ZA395sFmbvKNG3XrPp3KpnbFrdE3R3c93w5ZVfU2XWBzde5LLCBR1YRy8XwMibN7sG39o"
 ```
 
 ```shell--cli
@@ -1541,7 +1546,7 @@ let id, key;
 ```shell--vars
 id="multisig3"
 account="default"
-key="rpubKBBGCWqgVn4RRVpJTDUvTJnFHYiQuoUNy7s6W57U36KJ3r5inJp7iVRJZHvkFjbgfaGVs9fkvcCQS5ZMmc7BYFCrkADgmGKDCsjYK1vGmoFw"
+key="tpubDDkzvYzn2iJLqucWgnULe1x3DR5PCaZvWzpg13ZA395sFmbvKNG3XrPp3KpnbFrdE3R3c93w5ZVfU2XWBzde5LLCBR1YRy8XwMibN7sG39o"
 ```
 
 ```shell--cli
@@ -1611,7 +1616,7 @@ let id, address;
 
 ```shell--vars
 id="primary"
-address="RM4xYH2GrcHmiptfsDEF7Kqqbm2Humjm2E"
+address="msKYwEVXcKBxatPMfFLdVwYug6bz4YS87J"
 ```
 
 ```shell--cli
@@ -1651,11 +1656,11 @@ const wallet = walletClient.wallet(id);
   "index": 2,
   "witness": false,
   "nested": false,
-  "publicKey": "02548e0a23b90505f1b4017f52cf2beeaa399fce7ff2961e29570c6afdfa9bfc5b",
+  "publicKey": "03b28be4fd749be06233452542e9d602f97a9b9c292aed4e4669c3fcc499e366de",
   "script": null,
   "program": null,
   "type": "pubkeyhash",
-  "address": "RM4xYH2GrcHmiptfsDEF7Kqqbm2Humjm2E"
+  "address": "msKYwEVXcKBxatPMfFLdVwYug6bz4YS87J"
 }
 ```
 
@@ -1678,7 +1683,7 @@ let id, address;
 ```shell--vars
 id='primary'
 passphrase='secret123'
-address='RM4xYH2GrcHmiptfsDEF7Kqqbm2Humjm2E'
+address='msKYwEVXcKBxatPMfFLdVwYug6bz4YS87J'
 ```
 
 ```shell--cli
@@ -1712,7 +1717,7 @@ const wallet = walletClient.wallet(id);
 
 ```json
 {
-  "privateKey": "EPAcwFM5E6CS1sGCv3PDeJ68nXSfUZwViZ8HyrP9T8GcGSF14EsK"
+  "privateKey": "cNRiqwzRfcUfokNV8nSnDKb3NsKPhfRV2z5kBN11GKFb3GXkk1Hj"
 }
 ```
 
@@ -1772,16 +1777,15 @@ const wallet = walletClient.wallet(id);
   "name": "default",
   "account": 0,
   "branch": 0,
-  "index": 5,
+  "index": 3,
   "witness": false,
   "nested": false,
-  "publicKey": "030429c7a7007b9da542c029ea72a21852c2e4dfcce339d626df022068f0149680",
+  "publicKey": "03af169e5a186bbd7b380cb4553c72af243e18f243785b1597f192bbedd4a94fc3",
   "script": null,
   "program": null,
   "type": "pubkeyhash",
-  "address": "RUkNXekA1QcDzNZhn2TqNavPUxmaosCzJC"
+  "address": "n2eoT9D8txT5ZymDvCFPA8PHs2CmTV6oJT"
 }
-
 ```
 
 Derive new receiving address for account.
@@ -1843,16 +1847,15 @@ const wallet = walletClient.wallet(id);
   "name": "default",
   "account": 0,
   "branch": 1,
-  "index": 27,
+  "index": 3,
   "witness": false,
   "nested": false,
-  "publicKey": "02fb03c9c45cbc6436c7c009391bc1410f86da9f6548675e7521856d3b372dfb42",
+  "publicKey": "03853852949194b426608b55074c54bbb78791a80c1eeece1e83343fb8babe6129",
   "script": null,
   "program": null,
   "type": "pubkeyhash",
-  "address": "R9oeK9hgbBEYjmUffYyvPfh7eMw7q4v4XY"
+  "address": "mppKe3yeSqnwX6pSVFqCT1AVGYPbnncKGh"
 }
-[ec
 ```
 Derive new change address for account.
 
@@ -1917,11 +1920,11 @@ const wallet = walletClient.wallet(id);
   "index": 1,
   "witness": true,
   "nested": true,
-  "publicKey": "02d10d018aad643382a77f6f6305bd209879ae450f9d3fdbcc406a666a20b40332",
+  "publicKey": "02d4ac18c8422e1ed65b007bfaef9f6b5b5c2e7070d56806f2928f24e3c92ba04d",
   "script": null,
-  "program": "001421457f563883db273f4cefd519882dfefcb6ba82",
+  "program": "00142248d004cd1afca5fec1d8a92e3ef8de026b395d",
   "type": "scripthash",
-  "address": "GX9yN5m5dUcSqfmNgkfQ7XJAHdyvbTHLhU"
+  "address": "2NFQrQQSTWWCG3A9du6UNbDeDw1K3BQqQdu"
 }
 ```
 
@@ -2043,22 +2046,22 @@ const wallet = walletClient.wallet(id);
 [
   {
     "version": 1,
-    "height": -1,
-    "value": 4999998887,
-    "script": "76a914a2133747754faf7fbacc31bf0f74808f8409c4b388ac",
-    "address": "RQ4AZjpaoyXhEk3mjcWYR74YR8XhxoXGzV",
+    "height": 533,
+    "value": 54145,
+    "script": "0014b36ce46975f794a457ace76acf60e9e729afa9f6",
+    "address": "bcrt1qkdkwg6t47722g4avua4v7c8fuu56l20khg99xp",
     "coinbase": false,
-    "hash": "7c7de4c48744b09b69bd36ffdb354199407321e305c0a4bd366a6168e0ff7244",
+    "hash": "4d970cefa68cc09a4d591b106d551f2ab7ec5588fad34135e8bf0549acf1071f",
     "index": 1
   },
   {
     "version": 1,
-    "height": -1,
-    "value": 4999998887,
-    "script": "76a9149433dbda44a1f23396a1bd231443b0d29eb8cf2888ac",
-    "address": "RNnpD7tGaTpqEuTfBaqrtAqDK1927FLkW2",
+    "height": 533,
+    "value": 34296708683,
+    "script": "001478c6269acab13571f03ec97e6ef81c06a87d8b91",
+    "address": "bcrt1q0rrzdxk2ky6hrup7e9lxa7quq658mzu3yatkz4",
     "coinbase": false,
-    "hash": "a97a9993389ae321b263dffb68ba1312ad0655da83aeca75b2372d5abc70544a",
+    "hash": "af4fc1e2490a01f028e837a9a4cc2deef7760ca7c7373e53e2bf0f4f71a7b808",
     "index": 1
   },
   ...
@@ -2269,8 +2272,8 @@ let id, hash, index;
 
 ```shell--vars
 id="primary"
-hash="52ada542512ea95be425087ee4b891842d81eb6f9a4e0350f14d0285b5fd40c1"
-index="0"
+hash="d07a4211a3633bedd737b850378872191c27fc6126dc8131c3b45f62611a7f36"
+index="1"
 ```
 
 ```shell--cli
@@ -2307,13 +2310,13 @@ const wallet = walletClient.wallet(id);
 ```json
 {
   "version": 1,
-  "height": 104,
-  "value": 5000000000,
-  "script": "76a91403a394378a680558ea205b604b182566381e116e88ac",
-  "address": "R9cS4kuYVWHaDJmRGMpwx7zCNjw97Zm5LL",
-  "coinbase": true,
-  "hash": "52ada542512ea95be425087ee4b891842d81eb6f9a4e0350f14d0285b5fd40c1",
-  "index": 0
+  "height": 533,
+  "value": 34296788338,
+  "script": "001442079abdd9a01b9ccc5c6822413c06ce4e0c53d0",
+  "address": "bcrt1qggre40we5qdeenzudq3yz0qxee8qc57s2fqygy",
+  "coinbase": false,
+  "hash": "d07a4211a3633bedd737b850378872191c27fc6126dc8131c3b45f62611a7f36",
+  "index": 1
 }
 ```
 

--- a/api-docs-slate/source/includes/_wallet.md
+++ b/api-docs-slate/source/includes/_wallet.md
@@ -6,8 +6,7 @@ npm i -g bclient
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -89,8 +88,7 @@ bwallet-cli get --token=$token
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -172,8 +170,7 @@ bwallet-cli get
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -262,8 +259,7 @@ bwallet-cli mkwallet $id --witness=$witness --passphrase=$passphrase --watch-onl
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -364,8 +360,7 @@ curl $walleturl/$id/retoken \
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -420,8 +415,7 @@ bwallet-cli get --id=$id
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -501,8 +495,7 @@ bwallet-cli master --id=$id
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -591,8 +584,7 @@ curl $walleturl/$id/passphrase \
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -671,8 +663,7 @@ rate=1000
 value=20000
 address="RPipJ9yeeQxHn6YcBXd9WPy2V6cezzAuY8"
 
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -812,8 +803,7 @@ rate=1000
 value=5000000
 address="RPipJ9yeeQxHn6YcBXd9WPy2V6cezzAuY8"
 
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -935,8 +925,7 @@ curl $walleturl/$id/sign \
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -1043,8 +1032,7 @@ id="primary"
 account="default"
 age=259200 // 72 hours
 
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -1115,8 +1103,7 @@ curl $walleturl/$id/unlock \
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -1179,8 +1166,7 @@ curl $walleturl/$id/lock \
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -1247,8 +1233,7 @@ curl $walleturl/$watchid/import \
 
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -1326,8 +1311,7 @@ curl $walleturl/$id/import \
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -1385,8 +1369,7 @@ bwallet-cli blocks --id=$id
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -1438,8 +1421,7 @@ curl $walleturl/$id/block/$height
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -1504,8 +1486,7 @@ curl $walleturl/$id/shared-key \
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -1574,8 +1555,7 @@ curl $walleturl/$id/shared-key \
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -1643,8 +1623,7 @@ curl $walleturl/$id/key/$address
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -1711,8 +1690,7 @@ curl $walleturl/$id/wif/$address?passphrase=$passphrase
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -1769,8 +1747,7 @@ curl $walleturl/$id/address -X POST --data '{"account":"'$account'"}'
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -1841,8 +1818,7 @@ curl $walleturl/$id/change -X POST --data '{"account":"'$account'"}'
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -1913,8 +1889,7 @@ curl $walleturl/$id/nested -X POST --data '{"account": "'$account'"}'
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -1982,8 +1957,7 @@ curl $walleturl/$id/balance?account=$account
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -2045,8 +2019,7 @@ bwallet-cli --id=$id coins
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -2118,8 +2091,7 @@ curl $walleturl/$id/locked/$hash/$index -X PUT
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -2184,8 +2156,7 @@ curl $walleturl/$id/locked/$hash/$index -X DELETE
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -2249,8 +2220,7 @@ curl $walleturl/$id/locked
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -2314,8 +2284,7 @@ curl $walleturl/$id/coin/$hash/$index
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {

--- a/api-docs-slate/source/includes/_wallet_accounts.md
+++ b/api-docs-slate/source/includes/_wallet_accounts.md
@@ -58,8 +58,7 @@ bwallet-cli account --id=$id list
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -119,8 +118,7 @@ bwallet-cli --id=$id account get $account
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -203,8 +201,7 @@ curl $walleturl/$id/account/$name \
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {

--- a/api-docs-slate/source/includes/_wallet_accounts.md
+++ b/api-docs-slate/source/includes/_wallet_accounts.md
@@ -6,26 +6,26 @@
 {
   "name": "default",
   "initialized": true,
-  "witness": false,
+  "witness": true,
   "watchOnly": false,
   "type": "pubkeyhash",
   "m": 1,
   "n": 1,
   "accountIndex": 0,
-  "receiveDepth": 6,
-  "changeDepth": 9,
-  "nestedDepth": 0,
+  "receiveDepth": 152,
+  "changeDepth": 89,
+  "nestedDepth": 2,
   "lookahead": 10,
-  "receiveAddress": "RLY9z6PCB3fggt36mnfA75jESRtvkALKX5",
-  "changeAddress": "RPSppa2YUzTK5jWWZ7k74NfMEJtnNKn4vs",
-  "nestedAddress": null,
-  "accountKey": "rpubKBBuJXusEYaDdxTwH1nPYRXQnd3XgLAFfNYxVhjrtvLAkDAXaps1nURZVmWuFsXK8RBXiDQu7grCBv6fRtQxgPH3FkKe4UQV7F2sfNBK47sA",
+  "receiveAddress": "bcrt1qp3kym2sv7k23ndpqrv4hhcpzcm392l97hq932m",
+  "changeAddress": "bcrt1qkezyz65tq8k5gfyhs5v6jgzeplwsq84cscmczf",
+  "nestedAddress": "2NFQrQQSTWWCG3A9du6UNbDeDw1K3BQqQdu",
+  "accountKey": "tpubDDkzvYzn2iJLqucWgnULe1x3DR5PCaZvWzpg13ZA395sFmbvKNG3XrPp3KpnbFrdE3R3c93w5ZVfU2XWBzde5LLCBR1YRy8XwMibN7sG39o",
   "keys": [],
   "balance": {
-    "tx": 505,
-    "coin": 501,
-    "unconfirmed": 1339989996774,
-    "confirmed": 1339989999000
+    "tx": 157,
+    "coin": 80,
+    "unconfirmed": 102893658385,
+    "confirmed": 102893658385
   }
 }
 ```
@@ -142,26 +142,26 @@ const wallet = walletClient.wallet(id);
 {
   "name": "default",
   "initialized": true,
-  "witness": false,
+  "witness": true,
   "watchOnly": false,
   "type": "pubkeyhash",
   "m": 1,
   "n": 1,
   "accountIndex": 0,
-  "receiveDepth": 6,
-  "changeDepth": 9,
-  "nestedDepth": 0,
+  "receiveDepth": 152,
+  "changeDepth": 89,
+  "nestedDepth": 2,
   "lookahead": 10,
-  "receiveAddress": "RLY9z6PCB3fggt36mnfA75jESRtvkALKX5",
-  "changeAddress": "RPSppa2YUzTK5jWWZ7k74NfMEJtnNKn4vs",
-  "nestedAddress": null,
-  "accountKey": "rpubKBBuJXusEYaDdxTwH1nPYRXQnd3XgLAFfNYxVhjrtvLAkDAXaps1nURZVmWuFsXK8RBXiDQu7grCBv6fRtQxgPH3FkKe4UQV7F2sfNBK47sA",
+  "receiveAddress": "bcrt1qp3kym2sv7k23ndpqrv4hhcpzcm392l97hq932m",
+  "changeAddress": "bcrt1qkezyz65tq8k5gfyhs5v6jgzeplwsq84cscmczf",
+  "nestedAddress": "2NFQrQQSTWWCG3A9du6UNbDeDw1K3BQqQdu",
+  "accountKey": "tpubDDkzvYzn2iJLqucWgnULe1x3DR5PCaZvWzpg13ZA395sFmbvKNG3XrPp3KpnbFrdE3R3c93w5ZVfU2XWBzde5LLCBR1YRy8XwMibN7sG39o",
   "keys": [],
   "balance": {
-    "tx": 505,
-    "coin": 501,
-    "unconfirmed": 1339989996774,
-    "confirmed": 1339989999000
+    "tx": 157,
+    "coin": 80,
+    "unconfirmed": 102893658385,
+    "confirmed": 102893658385
   }
 }
 ```
@@ -224,22 +224,22 @@ const options = {name: name, type: type, passphrase: passphrase}
 
 ```json
 {
-  "name": "menace",
+  "name": "null",
   "initialized": true,
   "witness": false,
   "watchOnly": false,
-  "type": "multisig",
+  "type": "pubkeyhash",
   "m": 1,
   "n": 1,
-  "accountIndex": 1,
+  "accountIndex": 3,
   "receiveDepth": 1,
   "changeDepth": 1,
   "nestedDepth": 0,
   "lookahead": 10,
-  "receiveAddress": "GWzk797i4UCw9iG5uSj9DPQWsgt8nGWDA2",
-  "changeAddress": "GbqDrwBWDfKGgYuu4VvJGEjCpwxS5TiBdM",
+  "receiveAddress": "msciA3DK8mAAzj8u7MN53D8dYwXgHTwM59",
+  "changeAddress": "mkJNMxC1j4BWUmexzBbyM2T4uvnAGCFCV6",
   "nestedAddress": null,
-  "accountKey": "rpubKBBuJXusEYaDe2o6iEVjceYB4r7rGhfQGsHRynZ1pbaNvNB5eyo4GvvT3e6dfttpt6x5tomFjbooFj6vBjwpXMwJZcoFWr8LcmbW3BABQoxJ",
+  "accountKey": "tpubDC8ATY6G4mgAhJE9xRUEW2JNv6T5c1Vni7gKn1oUuwRzBh858H3Vx2baB8BG5Mh8UnLknZiT7nwnX8MHKKhKrUTduJXYdnskp43EJpSWdYB",
   "keys": [],
   "balance": {
     "tx": 0,

--- a/api-docs-slate/source/includes/_wallet_admin.md
+++ b/api-docs-slate/source/includes/_wallet_admin.md
@@ -37,8 +37,7 @@ bwallet-cli rescan $height
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -81,8 +80,7 @@ bwallet-cli resend
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -130,8 +128,7 @@ bwallet-cli backup $path
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -171,8 +168,7 @@ bwallet-cli wallets
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {

--- a/api-docs-slate/source/includes/_wallet_rpc.md
+++ b/api-docs-slate/source/includes/_wallet_rpc.md
@@ -182,7 +182,7 @@ None. |
 
 ```javascript
 let tx;
-let options={"changeAddress": "RGexEyDWWeHFMow51GYLYyfcRYzV4dq8CM", "feeRate": 0.00001000};
+let options={"changeAddress": "mfi6TVtSYsNk4ADkXbFT9d6f95kmDMXgKp", "feeRate": 0.00001000};
 ```
 
 ```shell--vars
@@ -190,7 +190,7 @@ tx='0100000000024e61bc00000000001976a914fbdd46898a6d70a682cbd34420ccf0b6bb644937
 ```
 
 ```shell--curl
-options='{"changeAddress": "RGexEyDWWeHFMow51GYLYyfcRYzV4dq8CM", "feeRate": 0.00001000}'
+options='{"changeAddress": "mfi6TVtSYsNk4ADkXbFT9d6f95kmDMXgKp", "feeRate": 0.00001000}'
 
 curl $walletrpcurl \
   -X POST \
@@ -201,7 +201,7 @@ curl $walletrpcurl \
 ```
 
 ```shell--cli
-options='{"changeAddress": "RGexEyDWWeHFMow51GYLYyfcRYzV4dq8CM", "feeRate": 0.00001000}'
+options='{"changeAddress": "mfi6TVtSYsNk4ADkXbFT9d6f95kmDMXgKp", "feeRate": 0.00001000}'
 
 bwallet-cli rpc fundrawtransaction $tx "$options"
 ```
@@ -435,7 +435,7 @@ let address;
 ```
 
 ```shell--vars
-address='RBQUN7J1earPLbu97MyvG4zhW5b8RAQxoG'
+address='msKYwEVXcKBxatPMfFLdVwYug6bz4YS87J'
 ```
 
 ```shell--curl
@@ -472,7 +472,7 @@ const walletClient = new WalletClient(walletOptions);
 > The above command returns JSON "result" like this:
 
 ```
-EPni2gZW3WrTU9sKRL8j73cZEffujYwx81LSvpMATGYavC88QN63
+cNRiqwzRfcUfokNV8nSnDKb3NsKPhfRV2z5kBN11GKFb3GXkk1Hj
 ```
 
 Get the private key (WIF format) corresponding to specified address.
@@ -492,7 +492,7 @@ let path;
 ```
 
 ```shell--vars
-path='/home/user/WalletDump'
+path='/home/user-1/secretfiles/dump1.txt'
 ```
 
 ```shell--curl
@@ -535,13 +535,16 @@ null
 > The contents of the wallet dump file are formatted like this:
 
 ```
-# Wallet Dump created by Bcoin v1.0.0-pre
-# * Created on 2018-07-10T21:03:58Z
-# * Best block at time of backup was 501 (12bd2d79bb2ee31ae109485fcb859c398e5e462bae3243a10c307e07c2a1144f).
-# * File: /home/ec2-user/WalletDump
+# Wallet Dump created by Bcoin 2.0.0-dev
+# * Created on 2019-10-22T18:29:15Z
+# * Best block at time of backup was 845 (72365e9f4b4ed638bb1600116a67e3fa59b6ad6be2a449b675db607a984da4f8).
+# * File: /home/user-1/secretfiles/dump1.txt
 
-EP3HH7RgveJ5CriwhDkZXXv3ZggtJ7ceooMoSBCG2PcaML2CYJ5y 2018-07-10T21:03:58Z label= addr=R9p6pdP7HmS7xYF1BofRWdb5Cgi2B1Xucf
-EMaRiAPcg4KACS4SvkxpxtMaJWkRnk5a1w8bwgX3avuycUJuRcZE 2018-07-10T21:03:58Z change=1 addr=RAyQMPqKdJHgGCD1DtZkjQ7LkhgnkdwhBP
+cNUUoZYmUGoJyodrNaohzfu6LmKy7pBk6yqubJcTeL5WPWw97DQ1 2019-10-22T18:29:15Z label= addr=mg54SV2ZubNQ5urTbd42mUsQ54byPvSg5j
+cNH7YBw6haTB3yWkAndoPhwXRLNibXjWAYpqRQdvqPKLeW7JAj6h 2019-10-22T18:29:15Z change=1 addr=mgj4oGTbvCHxvx4EESYJKPkXWamxh2R6ef
+cNmBeL4kpjLtNZcvjSezftq4ks6ajzZRi1z2AGpuBGy6XjxzytiQ 2019-10-22T18:29:15Z label= addr=mhX1xHbKGzw3r8FoN5bUkmRixHPEDNywxh
+cUEfRrvPpKCy87QReCmPmd74Hz68kgZEHAErkuvEDFqwJKcCLsMn 2019-10-22T18:29:15Z label= addr=mhcx3M1AitoiwDQS3sz42CQLpVCEVkJLfq
+cP4N8mxe81DhZfrgTz2GoV3croXD2o6Hern4DTB6Gr5jUwoLkT8h 2019-10-22T18:29:15Z change=1 addr=mhpSYq8bnM5XJVbpafdLNUtLZefr2d6xSq
 ...
 
 # End of dump
@@ -660,7 +663,7 @@ const walletClient = new WalletClient(walletOptions);
 > The above command returns JSON "result" like this:
 
 ```
-RAxFD5Ffxs9JuGDiu29DLstK9wfw8TMykU
+bcrt1qp3kym2sv7k23ndpqrv4hhcpzcm392l97hq932m
 ```
 
 Get the current receiving address for specified account.
@@ -679,7 +682,7 @@ let address;
 ```
 
 ```shell--vars
-address='RAxFD5Ffxs9JuGDiu29DLstK9wfw8TMykU'
+address='bcrt1qp3kym2sv7k23ndpqrv4hhcpzcm392l97hq932m'
 ```
 
 ```shell--curl
@@ -773,13 +776,13 @@ const walletClient = new WalletClient(walletOptions);
 
 ```json
 [
-  "RA15R2pAaz7WC3UGyVi5eSZTp77ADXJkih",
-  "RAur4Z6Af2E2YCZBSubFChZsPpWaNoypWE",
-  "RAxFD5Ffxs9JuGDiu29DLstK9wfw8TMykU",
-  "RBsWtxTNH6XFB2exRMTexuztTt6LGxBPw7",
-  "RDRPc4QRsot2Evxjt8HUa4wVsHyWRWDkhS",
-...
-  "RYCio4u5MYETZHa5yiGf1vsUAdeoMhLEoA"
+  "mg54SV2ZubNQ5urTbd42mUsQ54byPvSg5j",
+  "mgj4oGTbvCHxvx4EESYJKPkXWamxh2R6ef",
+  "mhX1xHbKGzw3r8FoN5bUkmRixHPEDNywxh",
+  "mhcx3M1AitoiwDQS3sz42CQLpVCEVkJLfq",
+  "mhpSYq8bnM5XJVbpafdLNUtLZefr2d6xSq",
+  ...
+  "mjQqy8E7WJLaybxHcpiaWQMppjizi6nG3Y"
 ]
 ```
 
@@ -881,7 +884,7 @@ const walletClient = new WalletClient(walletOptions);
 > The above command returns JSON "result" like this:
 
 ```
-RFkJezDrGMyY6yvpY6PSknM8B2vtCNYcRM
+msSaQkCXyrEefbSH9TCSWNjnacTwGGc55d
 ```
 
 Get the next receiving address from specified account, or `default` account.
@@ -926,7 +929,7 @@ const walletClient = new WalletClient(walletOptions);
 > The above command returns JSON "result" like this:
 
 ```
-RQbTXByrN77yhi232QSUCWc4NUmKtzfkiQ
+moKaYJdRT19YUWSsfhnTQpo68wkVvzkk8y
 ```
 
 Get the next change address from specified account.
@@ -1005,7 +1008,7 @@ let address, minconf;
 ```
 
 ```shell--vars
-address='RHstcGRQWYojDPrrpazjLMjLgcnwd1mvCb'
+address='bcrt1quvydwldtduzjpdz8nm79d30g49nt6u5nurw0dt'
 minconf=6
 ```
 
@@ -1102,25 +1105,25 @@ const walletClient = new WalletClient(walletOptions);
 
 ```json
 {
-  "amount": 50,
-  "blockhash": "0cb30fe6b2e2cb036103a15ad293c086d5f32846033f8d1dc1488bde0af945c1",
-  "blocktime": 1530218983,
-  "txid": "36cbb7ad0cc98ca86640a04c485f164dd741c20339af34516d359ecba2892c21",
+  "amount": 0.00072058,
+  "blockhash": "1134065cc665e4f6df36202307ea1c9ad31287c45a7b9a5196e446885a76fc1c",
+  "blocktime": 1571760038,
+  "txid": "bc8336f7bb88e9613d5d1e81bef73837d8ec1c2bd47b9e19c3c4bf1eeb7e03b8",
   "walletconflicts": [],
-  "time": 1530218983,
-  "timereceived": 1530218983,
+  "time": 1571759979,
+  "timereceived": 1571759979,
   "bip125-replaceable": "no",
   "details": [
     {
       "account": "default",
-      "address": "RHstcGRQWYojDPrrpazjLMjLgcnwd1mvCb",
+      "address": "bcrt1qvjewtg83j8w7halz0h2axlwcn6c2ver4u75avy",
       "category": "receive",
-      "amount": 50,
+      "amount": 0.00072058,
       "label": "default",
-      "vout": 0
+      "vout": 1
     }
   ],
-  "hex": "01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff1e510e6d696e65642062792062636f696e048e0e9256080000000000000000ffffffff0100f2052a010000001976a9145e50fb5b7475ebe2f7276ed3f29662e5321d1d7288ac00000000"
+  "hex": "010000000001013384747e0e0d5f7a8dfff4220c5bc25479a4abf674abe9ac5e5b77da7b2973050400000000ffffffff038f8f0000000000001976a9149a006584ab0383ef07ad289395118ed9fba0e45688ac7a1901000000000016001464b2e5a0f191ddebf7e27dd5d37dd89eb0a66475d97249fc0700000016001449f1b89f0b09bbf77f33035ed3d4c30bd90eade90248304502210098989192ba64b6d1008e6137bbffffcfc7c8b7d4d05fb4a03b6906f9ce1e6ed302204bf8c7915ed4b35b6120901fc7459b2dcfe62567f7d6649d451a2136ba15f6700121029bf6c7b020b6e106b8492c6a3d396a265566c6294f553d10557a274d572a0e9e00000000"
 }
 ```
 
@@ -1193,7 +1196,7 @@ let key, label, rescan;
 ```
 
 ```shell--vars
-key='ETHW2rL2CYrXBT57oWRWPvzcjgq79fvDobj2PsF1Y5onqyo4JTCV'
+key='cNH7YBw6haTB3yWkAndoPhwXRLNibXjWAYpqRQdvqPKLeW7JAj6h'
 label='this_is_ignored'
 rescan=false
 ```
@@ -1311,7 +1314,7 @@ let address;
 ```
 
 ```shell--vars
-address='RCFhpyWXkz5GxskL96q4KtceRXuAMnWUQo'
+address='mg54SV2ZubNQ5urTbd42mUsQ54byPvSg5j'
 ```
 
 ```shell--curl
@@ -1326,7 +1329,7 @@ curl $walletrpcurl \
 ```shell--cli
 bwallet-cli rpc importaddress $address
 
-# P2SH example, imports script as address GViEoofSJ7FywQVc1LcXKAbA8TvqDx5Rqv
+# P2SH example, imports script as address 2N57YNxkxUcUR9tXHsdEsvybTaAdsdc4fx
 bwallet-cli rpc importaddress 76a9145e50fb5b7475ebe2f7276ed3f29662e5321d1d7288ac "this_is_ignored" true true
 ```
 
@@ -1860,35 +1863,36 @@ const walletClient = new WalletClient(walletOptions);
 ```json
 [
   {
-    "involvesWatchonly": false,
-    "address": "RCmX71juh4q2CnKGP8U1UhtbSwj8rP92Vi",
-    "account": "hot",
-    "amount": 6.2500454,
-    "confirmations": 1,
-    "label": ""
-  },
-  {
-    "involvesWatchonly": false,
-    "address": "RHstcGRQWYojDPrrpazjLMjLgcnwd1mvCb",
+    "involvesWatchonly": true,
+    "address": "bcrt1ql8ll4v0u83uf3ghafr9f6c5slhnn7dfrxm499g",
     "account": "default",
-    "amount": 50,
-    "confirmations": 503,
+    "amount": 0.00030033,
+    "confirmations": 313,
     "label": ""
   },
   {
-    "involvesWatchonly": false,
-    "address": "RMY3VYzTQibiRZ4FiydqavrF3PdBVKuT4r",
+    "involvesWatchonly": true,
+    "address": "bcrt1qlfeauahf7jdpruxm6f2vax2yu3xsdkkw2z7n9g",
     "account": "default",
-    "amount": 46.87650028,
-    "confirmations": 1,
+    "amount": 0.00015496,
+    "confirmations": 321,
     "label": ""
   },
   {
-    "involvesWatchonly": false,
-    "address": "RYAhEzn27d7P7kcyhWbisFhe9u69SR6ajG",
-    "account": "savings",
-    "amount": 9.37345432,
-    "confirmations": 1,
+    "involvesWatchonly": true,
+    "address": "bcrt1qlaawtlmdcfjdegghxvdh5pqphk5fjhlevsup7s",
+    "account": "default",
+    "amount": 342.97828963,
+    "confirmations": 348,
+    "label": ""
+  },
+  ...
+  {
+    "involvesWatchonly": true,
+    "address": "bcrt1ql797szp8tvdday5r3zpeepc8fjfk4qs09uaq7t",
+    "account": "default",
+    "amount": 0.00091418,
+    "confirmations": 337,
     "label": ""
   }
 ]
@@ -1954,43 +1958,61 @@ const walletClient = new WalletClient(walletOptions);
 {
   "transactions": [
     {
-      "account": "savings",
-      "address": "RYAhEzn27d7P7kcyhWbisFhe9u69SR6ajG",
+      "account": "default",
+      "address": "bcrt1q730jd9qryjjd7wqyc3aw72mu8u3804m3qxz3qe",
       "category": "receive",
-      "amount": 0,
-      "label": "savings",
+      "amount": 0.00036954,
+      "label": "default",
       "vout": 0,
-      "confirmations": 1,
-      "blockhash": "26b5e76dcdfc51b94e8e09ca1cf55b453e6c542b7abb863df0a306c6f00ebc8e",
+      "confirmations": 314,
+      "blockhash": "142abcc5469da7684c84404f93b247b7948dc36933cd438360f611d05f3c62b8",
       "blockindex": -1,
-      "blocktime": 1531503617,
-      "blockheight": 503,
-      "txid": "3962a06342fc62a733700d74c075a5d24c4f44f7108f6d9a318b66e92e3bdc72",
+      "blocktime": 1571760040,
+      "blockheight": 532,
+      "txid": "5f5f496a6095f729755e22eec19484c0e2ea4b144ab266be722e0fe7e5a2ea98",
       "walletconflicts": [],
-      "time": 1531434894,
-      "timereceived": 1531434894,
+      "time": 1571759982,
+      "timereceived": 1571759982,
       "bip125-replaceable": "no"
     },
     {
-      "account": "hot",
-      "address": "RCmX71juh4q2CnKGP8U1UhtbSwj8rP92Vi",
+      "account": "default",
+      "address": "bcrt1qy86kqv3cxfqkemu4e7f6kzxzk2cyt6j6vsxptz",
       "category": "receive",
-      "amount": 6.2500454,
-      "label": "hot",
-      "vout": 0,
-      "confirmations": 1,
-      "blockhash": "26b5e76dcdfc51b94e8e09ca1cf55b453e6c542b7abb863df0a306c6f00ebc8e",
+      "amount": 0.00050209,
+      "label": "default",
+      "vout": 2,
+      "confirmations": 316,
+      "blockhash": "34d0385c667319c5225c7f82e025681bae2fb5df28809cc7cf432b491125c83c",
       "blockindex": -1,
-      "blocktime": 1531503617,
-      "blockheight": 503,
-      "txid": "1c526091b6bdff300cbdf8430e6dca9ea1ab2869d0b5d67e2097f9c9178b34b5",
+      "blocktime": 1571760040,
+      "blockheight": 530,
+      "txid": "9b7899e0800389aa293578ea14d03f9c7d0249faaced52c2120c20cde8f0479b",
       "walletconflicts": [],
-      "time": 1531503618,
-      "timereceived": 1531503618,
+      "time": 1571759982,
+      "timereceived": 1571759982,
+      "bip125-replaceable": "no"
+    },
+    {
+      "account": "default",
+      "address": "bcrt1q8nnvw4h09u6avx4tn8gkrx4t9ayd56v86q7ceg",
+      "category": "receive",
+      "amount": 0.00037547,
+      "label": "default",
+      "vout": 0,
+      "confirmations": 316,
+      "blockhash": "34d0385c667319c5225c7f82e025681bae2fb5df28809cc7cf432b491125c83c",
+      "blockindex": -1,
+      "blocktime": 1571760040,
+      "blockheight": 530,
+      "txid": "77a39583060aa3ff2a705d401fea0c07e77e95d66cc10b744dc95098cad1bee1",
+      "walletconflicts": [],
+      "time": 1571759981,
+      "timereceived": 1571759981,
       "bip125-replaceable": "no"
     }
   ],
-  "lastblock": "26b5e76dcdfc51b94e8e09ca1cf55b453e6c542b7abb863df0a306c6f00ebc8e"
+  "lastblock": "20b062aa8ff8a1611b86016c8ba4f0cec0a6c55b69f1f0431190018bd23d5aec"
 }
 ```
 
@@ -2052,21 +2074,56 @@ const walletClient = new WalletClient(walletOptions);
 ```json
 [
   {
-    "account": "hot",
-    "address": "RCmX71juh4q2CnKGP8U1UhtbSwj8rP92Vi",
+    "account": "default",
+    "address": "bcrt1qpqgnssrdfkfv9pkdj23c7k9w02x8n9ezv4nm3z",
     "category": "receive",
-    "amount": 6.2500454,
-    "label": "hot",
-    "vout": 0,
-    "confirmations": 11,
-    "blockhash": "26b5e76dcdfc51b94e8e09ca1cf55b453e6c542b7abb863df0a306c6f00ebc8e",
+    "amount": 0.00013937,
+    "label": "default",
+    "vout": 1,
+    "confirmations": 406,
+    "blockhash": "2ad44c048bc555d18f06d31065856ab3ea24c9a749d579f036aef102bddeabf9",
     "blockindex": -1,
-    "blocktime": 1531503617,
-    "blockheight": 503,
-    "txid": "1c526091b6bdff300cbdf8430e6dca9ea1ab2869d0b5d67e2097f9c9178b34b5",
+    "blocktime": 1571760025,
+    "blockheight": 440,
+    "txid": "675d4f09e1da5e9d8268de41ecdbb77795d738333caf6a7c86775211c19b6550",
     "walletconflicts": [],
-    "time": 1531503618,
-    "timereceived": 1531503618,
+    "time": 1571759957,
+    "timereceived": 1571759957,
+    "bip125-replaceable": "no"
+  },
+  {
+    "account": "",
+    "address": "bcrt1qh7jclanaex66gpkr5x4duyd45nltxvpppcqnw6",
+    "category": "send",
+    "amount": -0.00125648,
+    "vout": 1,
+    "confirmations": 404,
+    "blockhash": "53441b98c5286ef75e9aa431b2dd44adbef840b04a3b6c07ca79ff6a5e599373",
+    "blockindex": -1,
+    "blocktime": 1571760025,
+    "blockheight": 442,
+    "txid": "725ca556002481e4445110fa4c67fb31d4fdf436e4939bf3c8fa7ff93b1b6c89",
+    "walletconflicts": [],
+    "time": 1571759957,
+    "timereceived": 1571759957,
+    "bip125-replaceable": "no"
+  },
+  {
+    "account": "default",
+    "address": "bcrt1qpc0fu2fl3hdhf0kaheta67gzdfmfe90ga27pr6",
+    "category": "receive",
+    "amount": 0.00044896,
+    "label": "default",
+    "vout": 1,
+    "confirmations": 407,
+    "blockhash": "39e8e1d9f19389a3b92c5e024e5d7070fe48f4ca7bd0d045b119c09a155cebbf",
+    "blockindex": -1,
+    "blocktime": 1571760024,
+    "blockheight": 439,
+    "txid": "e346029655b10a9cd4df74d87d4001b1fd11ee7a6f53ab556cadb27ce160be14",
+    "walletconflicts": [],
+    "time": 1571759957,
+    "timereceived": 1571759957,
     "bip125-replaceable": "no"
   }
 ]
@@ -2089,7 +2146,7 @@ N. | Name | Default |  Description
 
 ```javascript
 let minconf, maxconf, addrs;
-addrs=["RYAhEzn27d7P7kcyhWbisFhe9u69SR6ajG"];
+addrs=["bcrt1qggre40we5qdeenzudq3yz0qxee8qc57s2fqygy"];
 ```
 
 ```shell--vars
@@ -2098,7 +2155,7 @@ maxconf=20
 ```
 
 ```shell--curl
-addrs='["RYAhEzn27d7P7kcyhWbisFhe9u69SR6ajG"]'
+addrs='["bcrt1qggre40we5qdeenzudq3yz0qxee8qc57s2fqygy"]'
 
 
 curl $walletrpcurl \
@@ -2110,7 +2167,7 @@ curl $walletrpcurl \
 ```
 
 ```shell--cli
-addrs='["RYAhEzn27d7P7kcyhWbisFhe9u69SR6ajG"]'
+addrs='["bcrt1qggre40we5qdeenzudq3yz0qxee8qc57s2fqygy"]'
 
 bwallet-cli rpc listunspent $minconf $maxconf $addrs
 ```
@@ -2138,13 +2195,13 @@ const walletClient = new WalletClient(walletOptions);
 ```json
 [
   {
-    "txid": "210e0393071dbfb029336238a5b9aa8f0608e0bb5e03a734d1f9d849d25707f5",
-    "vout": 0,
-    "address": "RYAhEzn27d7P7kcyhWbisFhe9u69SR6ajG",
-    "account": "savings",
-    "scriptPubKey": "76a914fb105362e7419bd437d3648fc926ebcd939ca4d888ac",
-    "amount": 6.25,
-    "confirmations": 12,
+    "txid": "d07a4211a3633bedd737b850378872191c27fc6126dc8131c3b45f62611a7f36",
+    "vout": 1,
+    "address": "bcrt1qggre40we5qdeenzudq3yz0qxee8qc57s2fqygy",
+    "account": "default",
+    "scriptPubKey": "001442079abdd9a01b9ccc5c6822413c06ce4e0c53d0",
+    "amount": 342.96788338,
+    "confirmations": 313,
     "spendable": true,
     "solvable": true
   }
@@ -2177,7 +2234,7 @@ let fromaccount, tobitcoinaddress, amount;
 
 ```shell--vars
 fromaccount='hot'
-tobitcoinaddress='RAxFD5Ffxs9JuGDiu29DLstK9wfw8TMykU'
+tobitcoinaddress='bcrt1qggre40we5qdeenzudq3yz0qxee8qc57s2fqygy'
 amount=0.0195
 ```
 
@@ -2236,7 +2293,7 @@ N. | Name | Default |  Description
 
 ```javascript
 let fromaccount, outputs, minconf, label, subtractFee;
-outputs={"REchKNnZ8ZMmLtWk57pCyLJWC9bUXKRUWW": 0.123, "RSj4jWhPWp6dyFKw8NaCHxWhzfUorfoskT": 0.321}
+outputs={"msSaQkCXyrEefbSH9TCSWNjnacTwGGc55d": 0.123, "moKaYJdRT19YUWSsfhnTQpo68wkVvzkk8y": 0.321}
 ```
 
 ```shell--vars
@@ -2247,7 +2304,7 @@ subtractfee=false
 ```
 
 ```shell--curl
-outputs='{"REchKNnZ8ZMmLtWk57pCyLJWC9bUXKRUWW": 0.123, "RSj4jWhPWp6dyFKw8NaCHxWhzfUorfoskT": 0.321}'
+outputs='{"msSaQkCXyrEefbSH9TCSWNjnacTwGGc55d": 0.123, "moKaYJdRT19YUWSsfhnTQpo68wkVvzkk8y": 0.321}'
 
 curl $walletrpcurl \
   -X POST \
@@ -2258,7 +2315,7 @@ curl $walletrpcurl \
 ```
 
 ```shell--cli
-outputs='{"REchKNnZ8ZMmLtWk57pCyLJWC9bUXKRUWW": 0.123, "RSj4jWhPWp6dyFKw8NaCHxWhzfUorfoskT": 0.321}'
+outputs='{"msSaQkCXyrEefbSH9TCSWNjnacTwGGc55d": 0.123, "moKaYJdRT19YUWSsfhnTQpo68wkVvzkk8y": 0.321}'
 
 bwallet-cli rpc sendmany $fromaccount "$outputs" $minconf $label $subtractfee
 ```
@@ -2307,7 +2364,7 @@ let address, amount, comment, comment_to, subtractFee;
 ```
 
 ```shell--vars
-address='REchKNnZ8ZMmLtWk57pCyLJWC9bUXKRUWW'
+address='moKaYJdRT19YUWSsfhnTQpo68wkVvzkk8y'
 amount=1.01010101
 comment="this_is_ignored"
 comment_to="this_is_ignored"
@@ -2434,7 +2491,7 @@ let address, message;
 ```
 
 ```shell--vars
-address='RFi4gigMWzFCNw774Cj67nomVZCRM6MpPn'
+address='moKaYJdRT19YUWSsfhnTQpo68wkVvzkk8y'
 message='Satoshi'
 ```
 
@@ -2472,7 +2529,7 @@ const walletClient = new WalletClient(walletOptions);
 > The above command returns JSON "result" like this:
 
 ```
-MEUCIQDHeECM3HRwD+FzueXV3iVxdX3ZT3tJurVOAgrRUnQeYgIgRIe1Onn/MrDQBF1nrwCZ2QkyaDWEXwsWo9C36kB4nGY=
+MEUCIQC5Zzr+JoenWHy7m9XxpbDVVeg3DvKvJVQNyYPvLOuB2gIgP/BT3dRItxarNbE8ajEoTI66q3eB4lo+/SLsp7bbP70=
 ```
 
 Sign an arbitrary message with the private key corresponding to a

--- a/api-docs-slate/source/includes/_wallet_rpc.md
+++ b/api-docs-slate/source/includes/_wallet_rpc.md
@@ -15,8 +15,7 @@ bwallet-cli rpc <method> <params>
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -88,8 +87,7 @@ bwallet-cli rpc selectwallet $id
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -134,8 +132,7 @@ bwallet-cli rpc getwalletinfo
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -210,8 +207,7 @@ bwallet-cli rpc fundrawtransaction $tx "$options"
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -269,8 +265,7 @@ bwallet-cli rpc resendwallettransactions
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -333,8 +328,7 @@ bwallet-cli rpc abandontransaction $tx
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -402,8 +396,7 @@ bwallet-cli rpc backupwallet $path
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -459,8 +452,7 @@ bwallet-cli rpc dumpprivkey $address
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -517,8 +509,7 @@ bwallet-cli rpc dumpwallet $path
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -590,8 +581,7 @@ bwallet-cli rpc encryptwallet $passphrase
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -650,8 +640,7 @@ bwallet-cli rpc getaccountaddress $account
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -707,8 +696,7 @@ bwallet-cli rpc getaccount $address
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -764,8 +752,7 @@ bwallet-cli rpc getaddressesbyaccount $account
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -818,8 +805,7 @@ bwallet-cli rpc getbalance
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -875,8 +861,7 @@ bwallet-cli rpc getnewaddress $account
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -921,8 +906,7 @@ bwallet-cli rpc getrawchangeaddress
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -979,8 +963,7 @@ bwallet-cli rpc getreceivedbyaccount $account $minconf
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -1040,8 +1023,7 @@ bwallet-cli rpc getreceivedbyaddress $address $minconf
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -1099,8 +1081,7 @@ bwallet-cli rpc gettransaction $txid
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -1166,8 +1147,7 @@ bwallet-cli rpc getunconfirmedbalance
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -1232,8 +1212,7 @@ bwallet-cli rpc importprivkey $key $label $rescan
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -1292,8 +1271,7 @@ bwallet-cli rpc importwallet $file $rescan
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -1353,8 +1331,7 @@ bwallet-cli rpc importaddress 76a9145e50fb5b7475ebe2f7276ed3f29662e5321d1d7288ac
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -1415,8 +1392,7 @@ bwallet-cli rpc importprunedfunds $rawtx $txoutproof
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -1477,8 +1453,7 @@ bwallet-cli rpc importpubkey $pubkey
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -1536,8 +1511,7 @@ bwallet-cli rpc keypoolrefill $newsize
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -1597,8 +1571,7 @@ bwallet-cli rpc listaccounts $minconf $watchonly
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -1672,8 +1645,7 @@ bwallet-cli rpc lockunspent true
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -1720,8 +1692,7 @@ bwallet-cli rpc listlockunspent
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -1785,8 +1756,7 @@ bwallet-cli rpc listreceivedbyaccount $minconf $includeEmpty $watchOnly
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -1868,8 +1838,7 @@ bwallet-cli rpc listreceivedbyaddress $minconf $includeEmpty $watchOnly
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -1962,8 +1931,7 @@ bwallet-cli rpc listsinceblock $block $minconf $watchOnly
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -2062,8 +2030,7 @@ bwallet-cli rpc listtransactions $account
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -2149,8 +2116,7 @@ bwallet-cli rpc listunspent $minconf $maxconf $addrs
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -2229,8 +2195,7 @@ bwallet-cli rpc sendfrom $fromaccount $tobitcoinaddress $amount
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -2299,8 +2264,7 @@ bwallet-cli rpc sendmany $fromaccount "$outputs" $minconf $label $subtractfee
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -2364,8 +2328,7 @@ bwallet-cli rpc sendtoaddress $address $amount $comment $commnt_to $subtractfee
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -2431,8 +2394,7 @@ bwallet-cli rpc settxfee $rate
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -2490,8 +2452,7 @@ bwallet-cli rpc signmessage $address $message
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -2540,8 +2501,7 @@ bwallet-cli rpc walletlock
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -2599,8 +2559,7 @@ bwallet-cli rpc walletpassphrasechange $old $passphrase
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -2658,8 +2617,7 @@ bwallet-cli rpc walletpassphrase $passphrase $timeout
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -2716,8 +2674,7 @@ bwallet-cli rpc removeprunedfunds $txid
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -2763,8 +2720,7 @@ bwallet-cli rpc getmemoryinfo
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -2827,8 +2783,7 @@ bwallet-cli rpc setloglevel $level
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -2876,8 +2831,7 @@ bwallet-cli rpc stop
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {

--- a/api-docs-slate/source/includes/_wallet_sockets.md
+++ b/api-docs-slate/source/includes/_wallet_sockets.md
@@ -63,8 +63,7 @@ All wallet events return the `wallet-id` in addition to the JSON data described 
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {

--- a/api-docs-slate/source/includes/_wallet_sockets.md
+++ b/api-docs-slate/source/includes/_wallet_sockets.md
@@ -112,30 +112,53 @@ They are:
 
 ```
 {
-  hash: '8f6492b8fbdf5d71322b32fb0ade956aed7ed761173108791f782001800be8e2',
-  height: -1,
-  block: null,
-  time: 0,
-  mtime: 1536690801,
-  date: '1970-01-01T00:00:00Z',
-  mdate: '2018-09-11T18:33:21Z',
-  size: 225,
-  virtualSize: 225,
-  fee: 4540,
-  rate: 20177,
-  confirmations: 0,
-  inputs: 
-   [ { value: 5000000000,
-       address: 'RQuXE6LxTC7WZTEZkpLxrTV2fX2aioBjrB',
-       path: [Object] } ],
-  outputs: 
-   [ { value: 10000000,
-       address: 'RQuXE6LxTC7WZTEZkpLxrTV2fX2aioBjrB',
-       path: [Object] },
-     { value: 4989995460,
-       address: 'RJBhmLQHUNNiJNpRkcKfSCs8bU47Ew8zgU',
-       path: [Object] } ],
-  tx: '01000000010260ea8f1c4c0609a89a2120654cc7a2bf903dbd408d23b9d42614ef199ff063000000006a473044022036ee7381ad177e140d77123eab15e980535f2ae581c2fe633160d565f153c3e802205d348e0a49b4ed1b87e3c12665a8a61f1477ed40639b883c0190a15011e17a1e0121025ad70d43d5844fec60a406515ff86b96ac5b9c5c8c186ae571198986e23322beffffffff0280969800000000001976a914ab68d8609ddd31698303963d642164f29392e32a88acc4496d29010000001976a91461af6ad7fa4037ec97207944ac220565e98a3ab388ac00000000'
+  "hash": "e0ef577e307b9b798bf98a7aa56ebab431d1918f6c8b29ddd8a89dce5314acca",
+  "height": -1,
+  "block": null,
+  "time": 0,
+  "mtime": 1571774743,
+  "date": "1970-01-01T00:00:00Z",
+  "mdate": "2019-10-22T20:05:43Z",
+  "size": 226,
+  "virtualSize": 226,
+  "fee": 4540,
+  "rate": 20088,
+  "confirmations": 0,
+  "inputs": [
+    {
+      "value": 2500000000,
+      "address": "mhX1xHbKGzw3r8FoN5bUkmRixHPEDNywxh",
+      "path": {
+        "name": "default",
+        "account": 0,
+        "change": false,
+        "derivation": "m/0'/0/1"
+      }
+    }
+  ],
+  "outputs": [
+    {
+      "value": 10000000,
+      "address": "msSaQkCXyrEefbSH9TCSWNjnacTwGGc55d",
+      "path": {
+        "name": "default",
+        "account": 0,
+        "change": false,
+        "derivation": "m/0'/0/4"
+      }
+    },
+    {
+      "value": 2489995460,
+      "address": "mtwN3Z4R7Mjdn1Dt6eDCUwoPdYKNFu6oiX",
+      "path": {
+        "name": "default",
+        "account": 0,
+        "change": true,
+        "derivation": "m/0'/1/5"
+      }
+    }
+  ],
+  "tx": "0100000001bf932f6585ce47d552c9f18463820bb4064b97b032606a122947aba4e14f77e6000000006b4830450221009aa7abc5bcc058bbb3c85ea53fdc19bae9351a81ad3f6027b6dfc0437fb1010502202e768a07a9e073833fc7039bebfd5b9b4edc373159e93d5917f074c53355187201210336c99e45e00b73c863497a989fe6feb08439ca2d7cf98f55bc261ed70ed28a7bffffffff0280969800000000001976a91482cd93c2cbdd094599a92ce3317d3087a1975e0a88acc4506a94000000001976a9149337719ab611d0da2ec1317dd195844661e3732f88ac00000000"
 }
 ```
 
@@ -156,30 +179,53 @@ Returns tx details of removed double spender.
 
 ```
 {
-  hash: '8f6492b8fbdf5d71322b32fb0ade956aed7ed761173108791f782001800be8e2',
-  height: 114,
-  block: '67e73bd4d08397cbc96f605fa4e3e0bd2d7eeb865309ccfd0cf885fab3d1c966',
-  time: 1536690803,
-  mtime: 1536690801,
-  date: '2018-09-11T18:33:23Z',
-  mdate: '2018-09-11T18:33:21Z',
-  size: 225,
-  virtualSize: 225,
-  fee: 4540,
-  rate: 20177,
-  confirmations: 1,
-  inputs: 
-   [ { value: 5000000000,
-       address: 'RQuXE6LxTC7WZTEZkpLxrTV2fX2aioBjrB',
-       path: [Object] } ],
-  outputs: 
-   [ { value: 10000000,
-       address: 'RQuXE6LxTC7WZTEZkpLxrTV2fX2aioBjrB',
-       path: [Object] },
-     { value: 4989995460,
-       address: 'RJBhmLQHUNNiJNpRkcKfSCs8bU47Ew8zgU',
-       path: [Object] } ],
-  tx: '01000000010260ea8f1c4c0609a89a2120654cc7a2bf903dbd408d23b9d42614ef199ff063000000006a473044022036ee7381ad177e140d77123eab15e980535f2ae581c2fe633160d565f153c3e802205d348e0a49b4ed1b87e3c12665a8a61f1477ed40639b883c0190a15011e17a1e0121025ad70d43d5844fec60a406515ff86b96ac5b9c5c8c186ae571198986e23322beffffffff0280969800000000001976a914ab68d8609ddd31698303963d642164f29392e32a88acc4496d29010000001976a91461af6ad7fa4037ec97207944ac220565e98a3ab388ac00000000'
+  "hash": "e0ef577e307b9b798bf98a7aa56ebab431d1918f6c8b29ddd8a89dce5314acca",
+  "height": 846,
+  "block": "636982487fccf820bc1ca825b2cdd94be1bdd9863e8dec01979b62b45d894e73",
+  "time": 1571774818,
+  "mtime": 1571774743,
+  "date": "2019-10-22T20:06:58Z",
+  "mdate": "2019-10-22T20:05:43Z",
+  "size": 226,
+  "virtualSize": 226,
+  "fee": 4540,
+  "rate": 20088,
+  "confirmations": 1,
+  "inputs": [
+    {
+      "value": 2500000000,
+      "address": "mhX1xHbKGzw3r8FoN5bUkmRixHPEDNywxh",
+      "path": {
+        "name": "default",
+        "account": 0,
+        "change": false,
+        "derivation": "m/0'/0/1"
+      }
+    }
+  ],
+  "outputs": [
+    {
+      "value": 10000000,
+      "address": "msSaQkCXyrEefbSH9TCSWNjnacTwGGc55d",
+      "path": {
+        "name": "default",
+        "account": 0,
+        "change": false,
+        "derivation": "m/0'/0/4"
+      }
+    },
+    {
+      "value": 2489995460,
+      "address": "mtwN3Z4R7Mjdn1Dt6eDCUwoPdYKNFu6oiX",
+      "path": {
+        "name": "default",
+        "account": 0,
+        "change": true,
+        "derivation": "m/0'/1/5"
+      }
+    }
+  ],
+  "tx": "0100000001bf932f6585ce47d552c9f18463820bb4064b97b032606a122947aba4e14f77e6000000006b4830450221009aa7abc5bcc058bbb3c85ea53fdc19bae9351a81ad3f6027b6dfc0437fb1010502202e768a07a9e073833fc7039bebfd5b9b4edc373159e93d5917f074c53355187201210336c99e45e00b73c863497a989fe6feb08439ca2d7cf98f55bc261ed70ed28a7bffffffff0280969800000000001976a91482cd93c2cbdd094599a92ce3317d3087a1975e0a88acc4506a94000000001976a9149337719ab611d0da2ec1317dd195844661e3732f88ac00000000"
 }
 ```
 
@@ -223,17 +269,17 @@ Returns Balance object.
 ```
 [
   {
-    name: 'default',
-    account: 0,
-    branch: 0,
-    index: 13,
-    witness: false,
-    nested: false,
-    publicKey: '0268bff8723598210c7f8fa52edbfdfaaae1f1b1377fa77bc6ac550f9e5875f844',
-    script: null,
-    program: null,
-    type: 'pubkeyhash',
-    address: 'R9zQNo4U7bUXzT7QJmVxKBrmJfp67wrK7h'
+    "name": "default",
+    "account": 0,
+    "branch": 0,
+    "index": 16,
+    "witness": false,
+    "nested": false,
+    "publicKey": "0370d759cf5170e718ab02fccf844bc69a3c9ad6ece9899be55455930fb85ff674",
+    "script": null,
+    "program": null,
+    "type": "pubkeyhash",
+    "address": "mfzcPvKYNjzULJRjbaAhdR8fEJsTg7SSsV"
   }
 ]
 ```

--- a/api-docs-slate/source/includes/_wallet_tx.md
+++ b/api-docs-slate/source/includes/_wallet_tx.md
@@ -20,8 +20,7 @@ curl $walleturl/$id/tx/$hash
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -147,8 +146,7 @@ curl $walleturl/$id/tx/history
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -243,8 +241,7 @@ curl $walleturl/$id/tx/unconfirmed
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {
@@ -295,8 +292,7 @@ curl $walleturl/$id/tx/range?start=$start'&'end=$end
 ```
 
 ```javascript
-const {WalletClient} = require('bclient');
-const {Network} = require('bcoin');
+const {WalletClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 const walletOptions = {

--- a/api-docs-slate/source/includes/_wallet_tx.md
+++ b/api-docs-slate/source/includes/_wallet_tx.md
@@ -41,43 +41,53 @@ const wallet = walletClient.wallet(id);
 
 ```json
 {
-  "hash": "c7dcd8f8923f8cd0d44d0d980ddd4da80f67290ef872aab0f7be5858210712f7",
-  "height": 501,
-  "block": "05b1fa9da2acc862dd8e329bbcd158f240a844951016d9e9cd1a1bf9f61b9ac9",
-  "time": 1527184717,
-  "mtime": 1527184717,
-  "date": "2018-05-24T17:58:37Z",
-  "mdate": "2018-05-24T17:58:37Z",
-  "size": 200,
-  "virtualSize": 173,
-  "fee": 0,
-  "rate": 0,
-  "confirmations": 1,
+  "hash": "292fbf4fb037a5354465e0a183d664b99477248f1dd14f47493a2a66a66f40b4",
+  "height": -1,
+  "block": null,
+  "time": 0,
+  "mtime": 1571774862,
+  "date": "1970-01-01T00:00:00Z",
+  "mdate": "2019-10-22T20:07:42Z",
+  "size": 226,
+  "virtualSize": 226,
+  "fee": 4540,
+  "rate": 20088,
+  "confirmations": 0,
   "inputs": [
     {
-      "value": 0,
-      "address": null,
-      "path": null
-    }
-  ],
-  "outputs": [
-    {
-      "value": 625009040,
-      "address": "RQCqU5msz7DbNGtti6fYQajEGDY2oabsvN",
+      "value": 2500000000,
+      "address": "mhX1xHbKGzw3r8FoN5bUkmRixHPEDNywxh",
       "path": {
         "name": "default",
         "account": 0,
         "change": false,
         "derivation": "m/0'/0/1"
       }
-    },
-    {
-      "value": 0,
-      "address": null,
-      "path": null
     }
   ],
-  "tx": "010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff2002f5010e6d696e65642062792062636f696e04f410f00b080000000000000000ffffffff0290e14025000000001976a914a3b7048d9f72788e1e2e161dc63585322689d01388ac0000000000000000266a24aa21a9ed9dae2d79e9b97a2b1f19bb16dd1c1c633f2fce683fba82eb85248fac3e32f3d90120000000000000000000000000000000000000000000000000000000000000000000000000"
+  "outputs": [
+    {
+      "value": 10000000,
+      "address": "mxbdj9hHDLK2TXD3Cztiy8BLiEuKPcsM5x",
+      "path": {
+        "name": "default",
+        "account": 0,
+        "change": false,
+        "derivation": "m/0'/0/5"
+      }
+    },
+    {
+      "value": 2489995460,
+      "address": "mjQqy8E7WJLaybxHcpiaWQMppjizi6nG3Y",
+      "path": {
+        "name": "default",
+        "account": 0,
+        "change": true,
+        "derivation": "m/0'/1/6"
+      }
+    }
+  ],
+  "tx": "0100000001a02535c04f1791c7cee4a299d55179d998c23c41c039778ce10d7d3150695b10000000006b483045022100c7ce594aadde910687a6a86ee48a865221066d47b8a2323d10683076d399938e022048844ec1ad29c3733d13ac191a3bc89a1f07abc0f240ae631e5d146acc11f6e901210336c99e45e00b73c863497a989fe6feb08439ca2d7cf98f55bc261ed70ed28a7bffffffff0280969800000000001976a914bb5cb80bfffca7ba777ff3a8f7c33098faf9769188acc4506a94000000001976a9142ab8b9f49d7c3559b4228aa69b1e8cba0a7558d088ac00000000"
 }
 ```
 Get wallet transaction details.
@@ -169,45 +179,54 @@ const account = 'default';
 ```json
 [
   {
-     "wid": 1,
-     "id": "primary",
-     "hash": "f5968051ce275d89b7a6b797eb6e6b081243ecf027872fc6949fae443e21b858",
-     "height": -1,
-     "block": null,
-     "time": 0,
-     "mtime": 1503690544,
-     "date": "2017-08-25T19:49:04Z",
-     "size": 226,
-     "virtualSize": 226,
-     "fee": 0,
-     "rate": 0,
-     "confirmations": 0,
-     "inputs": [
-       {
-         "value": 0,
-         "address": "mp2w1u4oqZnHDd1zDeAvCTX9B3SaFsUFQx",
-         "path": null
-       }
-     ],
-     "outputs": [
-       {
-         "value": 100000,
-         "address": "myCkrhQbJwqM8wKi9YuhyTjN3pukNuWxZ9",
-         "path": {
-           "name": "default",
-           "account": 0,
-           "change": false,
-           "derivation": "m/0'/0/3"
-         }
-       },
-       {
-         "value": 29790920,
-         "address": "mqNm1rSYVqD23Aj6fkupApuSok9DNZAeBk",
-         "path": null
-       }
-     ],
-     "tx": "0100000001ef8a38cc946c57634c2db05fc298bf94f5c88829c5a6e2b0610fcc7b38a9264f010000006b483045022100e98db5ddb92686fe77bb44f86ce8bf6ff693c1a1fb2fb434c6eeed7cf5e7bed4022053dca3980a902ece82fb8e9e5204c26946893388e4663dbb71e78946f49dd0f90121024c4abc2a3683891b35c04e6d40a07ee78e7d86ad9d7a14265fe214fe84513676ffffffff02a0860100000000001976a914c2013ac1a5f6a9ae91f66e71bbfae4cc762c2ca988acc892c601000000001976a9146c2483bf52052e1125fc75dd77dad06d65b70a8288ac00000000"
-   },
+    "hash": "292fbf4fb037a5354465e0a183d664b99477248f1dd14f47493a2a66a66f40b4",
+    "height": -1,
+    "block": null,
+    "time": 0,
+    "mtime": 1571774862,
+    "date": "1970-01-01T00:00:00Z",
+    "mdate": "2019-10-22T20:07:42Z",
+    "size": 226,
+    "virtualSize": 226,
+    "fee": 4540,
+    "rate": 20088,
+    "confirmations": 0,
+    "inputs": [
+      {
+        "value": 2500000000,
+        "address": "mhX1xHbKGzw3r8FoN5bUkmRixHPEDNywxh",
+        "path": {
+          "name": "default",
+          "account": 0,
+          "change": false,
+          "derivation": "m/0'/0/1"
+        }
+      }
+    ],
+    "outputs": [
+      {
+        "value": 10000000,
+        "address": "mxbdj9hHDLK2TXD3Cztiy8BLiEuKPcsM5x",
+        "path": {
+          "name": "default",
+          "account": 0,
+          "change": false,
+          "derivation": "m/0'/0/5"
+        }
+      },
+      {
+        "value": 2489995460,
+        "address": "mjQqy8E7WJLaybxHcpiaWQMppjizi6nG3Y",
+        "path": {
+          "name": "default",
+          "account": 0,
+          "change": true,
+          "derivation": "m/0'/1/6"
+        }
+      }
+    ],
+    "tx": "0100000001a02535c04f1791c7cee4a299d55179d998c23c41c039778ce10d7d3150695b10000000006b483045022100c7ce594aadde910687a6a86ee48a865221066d47b8a2323d10683076d399938e022048844ec1ad29c3733d13ac191a3bc89a1f07abc0f240ae631e5d146acc11f6e901210336c99e45e00b73c863497a989fe6feb08439ca2d7cf98f55bc261ed70ed28a7bffffffff0280969800000000001976a914bb5cb80bfffca7ba777ff3a8f7c33098faf9769188acc4506a94000000001976a9142ab8b9f49d7c3559b4228aa69b1e8cba0a7558d088ac00000000"
+  },
  ...
 ]
 ```
@@ -314,43 +333,53 @@ const wallet = walletClient.wallet(id);
 ```json
 [
   {
-    "hash": "c7dcd8f8923f8cd0d44d0d980ddd4da80f67290ef872aab0f7be5858210712f7",
-    "height": 501,
-    "block": "05b1fa9da2acc862dd8e329bbcd158f240a844951016d9e9cd1a1bf9f61b9ac9",
-    "time": 1527184717,
-    "mtime": 1527184717,
-    "date": "2018-05-24T17:58:37Z",
-    "mdate": "2018-05-24T17:58:37Z",
-    "size": 200,
-    "virtualSize": 173,
-    "fee": 0,
-    "rate": 0,
-    "confirmations": 1,
+    "hash": "292fbf4fb037a5354465e0a183d664b99477248f1dd14f47493a2a66a66f40b4",
+    "height": -1,
+    "block": null,
+    "time": 0,
+    "mtime": 1571774862,
+    "date": "1970-01-01T00:00:00Z",
+    "mdate": "2019-10-22T20:07:42Z",
+    "size": 226,
+    "virtualSize": 226,
+    "fee": 4540,
+    "rate": 20088,
+    "confirmations": 0,
     "inputs": [
       {
-        "value": 0,
-        "address": null,
-        "path": null
-      }
-    ],
-    "outputs": [
-      {
-        "value": 625009040,
-        "address": "RQCqU5msz7DbNGtti6fYQajEGDY2oabsvN",
+        "value": 2500000000,
+        "address": "mhX1xHbKGzw3r8FoN5bUkmRixHPEDNywxh",
         "path": {
           "name": "default",
           "account": 0,
           "change": false,
           "derivation": "m/0'/0/1"
         }
-      },
-      {
-        "value": 0,
-        "address": null,
-        "path": null
       }
     ],
-    "tx": "010000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff2002f5010e6d696e65642062792062636f696e04f410f00b080000000000000000ffffffff0290e14025000000001976a914a3b7048d9f72788e1e2e161dc63585322689d01388ac0000000000000000266a24aa21a9ed9dae2d79e9b97a2b1f19bb16dd1c1c633f2fce683fba82eb85248fac3e32f3d90120000000000000000000000000000000000000000000000000000000000000000000000000"
+    "outputs": [
+      {
+        "value": 10000000,
+        "address": "mxbdj9hHDLK2TXD3Cztiy8BLiEuKPcsM5x",
+        "path": {
+          "name": "default",
+          "account": 0,
+          "change": false,
+          "derivation": "m/0'/0/5"
+        }
+      },
+      {
+        "value": 2489995460,
+        "address": "mjQqy8E7WJLaybxHcpiaWQMppjizi6nG3Y",
+        "path": {
+          "name": "default",
+          "account": 0,
+          "change": true,
+          "derivation": "m/0'/1/6"
+        }
+      }
+    ],
+    "tx": "0100000001a02535c04f1791c7cee4a299d55179d998c23c41c039778ce10d7d3150695b10000000006b483045022100c7ce594aadde910687a6a86ee48a865221066d47b8a2323d10683076d399938e022048844ec1ad29c3733d13ac191a3bc89a1f07abc0f240ae631e5d146acc11f6e901210336c99e45e00b73c863497a989fe6feb08439ca2d7cf98f55bc261ed70ed28a7bffffffff0280969800000000001976a914bb5cb80bfffca7ba777ff3a8f7c33098faf9769188acc4506a94000000001976a9142ab8b9f49d7c3559b4228aa69b1e8cba0a7558d088ac00000000"
   },
   ...
 ]

--- a/api-docs-slate/source/index.html.md
+++ b/api-docs-slate/source/index.html.md
@@ -50,7 +50,11 @@ The default bcoin HTTP server listens on the standard RPC port (`8332` for main,
 <aside class="notice">
 These docs have been updated to latest version of bcoin and bclient as of October 2019 (bcoin version <code>v2.0.0-dev</code>).
 As of this writing the bcoin npm repository has not yet been updated, so it is recommended to install from the latest master branch on github. 
-Installation instructions are available there: <a href="https://github.com/bcoin-org/bcoin">https://github.com/bcoin-org/bcoin</a>
+Installation instructions are available there: <a href="https://github.com/bcoin-org/bcoin">https://github.com/bcoin-org/bcoin</a>.
+<br><br>
+Note that <a href="https://github.com/bcoin-org/bcoin/pull/838">recently</a> the API clients have been moved back in to the <code>bcoin</code> repository.
+<code>bclient</code> is still available on npm and github but may not reflect the latest updates to the API. We therefore recommend using the
+<code>NodeClient</code> and <code>WalletClient</code> objects as defiend in <code>bcoin/lib/client</code>, and as described in these docs.
 </aside>
 
 # Authentication
@@ -75,8 +79,7 @@ bcoin-cli info
 ```
 
 ```javascript
-const {NodeClient} = require('bclient');
-const {Network} = require('bcoin');
+const {NodeClient, Network} = require('bcoin');
 const network = Network.get('regtest');
 
 // network type derived from bcoin object, client object stores API key


### PR DESCRIPTION
Address https://github.com/bcoin-org/bcoin-org.github.io/pull/160#issuecomment-544709129

Depends on:
https://github.com/bcoin-org/bcoin/pull/889 (bcoin-cli: expose estimateFee)
https://github.com/bcoin-org/bcoin/pull/890 (bwallet-cli: add sign parameter)
...and may need to be updated depending on the progress of those PRs.

Updates for `2.0.0-dev`:
- Display updated `get info` response including filter indexer and version number
- Add `/header` and details, examples
- Add `/filter` and details, examples
- Add details and examples for existing call `/fee` (see https://github.com/bcoin-org/bcoin/pull/889 )
- Link commands in table to individual sections of the docs for better UX.
- Deprecate `bclient` for `NodeClient` and `WalletClient` and get those from `bcoin` instead
- Replace all example with the old Regtest addresses and key prefixes

TODO:
- [x] `/filter` endpoint
- [x] Switch all javascript examples from `bclient` to `bcoin`
- [x] Update all regtest addresses and key prefixes