### PR TITLE
Nits: add host to client options, clarify params to broadcast tx

### DIFF
--- a/api-docs-slate/source/includes/_clients.md
+++ b/api-docs-slate/source/includes/_clients.md
@@ -107,7 +107,7 @@ const wallet = new WalletClient(walletOptions);
 
 You can also use the API with a Javascript library (used by `bcoin-cli`).
 There are two objects: `NodeClient` for general API and `WalletClient` for wallet API.
-`bcoin` also provides an object `Network` and its method `get` which will return the default configuration paramaters for a specified network.
+`bcoin` also provides an object `Network` and its method `get` which will return the default configuration parameters for a specified network.
 Custom port numbers are also configurable by the user.
 
 `NodeClient` and `WalletClient` options:

--- a/api-docs-slate/source/includes/_clients.md
+++ b/api-docs-slate/source/includes/_clients.md
@@ -115,6 +115,7 @@ Custom port numbers are also configurable by the user.
 Config    | Type                         | Description
 --------- | -----------                  | -----------
 network   | _string_ | Network to use: `main`, `testnet`, `regtest`
-port      | _int_                          | bcoin socket port (specific for each network)
+port      | _int_                          | bcoin socket port (defaults specific for each network)
+host      | _string_ | bcoin API host URI (defaults to 127.0.0.1)
 apiKey    | _string_                       | API secret
 

--- a/api-docs-slate/source/includes/_node.md
+++ b/api-docs-slate/source/includes/_node.md
@@ -456,7 +456,7 @@ Broadcast a transaction by adding it to the node's mempool. If mempool verificat
 ### POST Parameters (JSON)
 Parameter | Description
 --------- | -----------
-tx | transaction hash
+tx | raw transaction in hex
 
 
 ## Estimate fee

--- a/api-docs-slate/source/includes/_wallet.md
+++ b/api-docs-slate/source/includes/_wallet.md
@@ -752,7 +752,7 @@ Watch carefully how values are entered in the examples, all examples send the sa
 
 `POST /wallet/:id/send`
 
-### Post Paramaters
+### Post Parameters
 Parameter | Description
 --------- | ------------------
 outputs <br> _array_ | An array of outputs to send for the transaction
@@ -1080,7 +1080,7 @@ Remove all pending transactions older than a specified age.
 `POST /wallet/:id/zap?age=3600`
 
 ### Post Parameters
-Paramaters | Description
+Parameters | Description
 ----------- | -------------
 account <br> _string_ or _number_ | account to zap from
 age <br> _number_ | age threshold to zap up to (unix time)
@@ -1463,7 +1463,7 @@ Get block info by height.
 
 `GET /wallet/:id/block/:height`
 
-Paramaters | Description
+Parameters | Description
 -----------| -------------
 id <br> _string_ | id of wallet which has tx in the block being queried
 height <br> _int_ | height of block being queried

--- a/api-docs-slate/source/index.html.md
+++ b/api-docs-slate/source/index.html.md
@@ -112,7 +112,7 @@ This string could be saved in <code>bcoin.conf</code> to persist over restarts, 
 at launch (for example):<br>
 <code>bcoin --api-key=92ded8555d6f04e440ba540f2221349cbf799c454f7e08d3f16577d3e0127b0e</code><br>
 <br>
-For more information about <code>bcoin.conf</code> and other launch paramaters, see
+For more information about <code>bcoin.conf</code> and other launch parameters, see
 <a href="https://github.com/bcoin-org/bcoin/blob/master/docs/configuration.md">docs/Configuration</a>.
 </aside>
 


### PR DESCRIPTION
Closes https://github.com/bcoin-org/bcoin/issues/940 

and fixes a typo in broadcast tx.