### PR TITLE
Added ssl to javascript client connection 

### DIFF
--- a/api-docs-slate/source/includes/_clients.md
+++ b/api-docs-slate/source/includes/_clients.md
@@ -118,4 +118,5 @@ network   | _string_ | Network to use: `main`, `testnet`, `regtest`
 port      | _int_                          | bcoin socket port (defaults specific for each network)
 host      | _string_ | bcoin API host URI (defaults to 127.0.0.1)
 apiKey    | _string_                       | API secret
+ssl       | _boolean_                      | TLS (defaults to false: `http`)
 

--- a/api-docs-slate/source/includes/_clients.md
+++ b/api-docs-slate/source/includes/_clients.md
@@ -118,5 +118,5 @@ network   | _string_ | Network to use: `main`, `testnet`, `regtest`
 port      | _int_                          | bcoin socket port (defaults specific for each network)
 host      | _string_ | bcoin API host URI (defaults to 127.0.0.1)
 apiKey    | _string_                       | API secret
-ssl       | _boolean_                      | TLS (defaults to false: `http`)
+ssl       | _boolean_                      | TLS (defaults to false: `http`, unless url has `https`)
 


### PR DESCRIPTION
https://bcoin.io/api-docs/index.html?javascript#using-javascript-clients , Connecting to nodes that have SSL( `https`) enabled is using [bclient](https://www.npmjs.com/package/bclient) not specified in the documentation 