### PR TITLE
api-docs: fixed order of arguments in setpassphrase

### DIFF
--- a/api-docs-slate/source/includes/_wallet.md
+++ b/api-docs-slate/source/includes/_wallet.md
@@ -596,7 +596,7 @@ const walletClient = new WalletClient(walletOptions);
 const wallet = walletClient.wallet(id);
 
 (async () => {
-  const result = await wallet.setPassphrase(oldPass, newPass);
+  const result = await wallet.setPassphrase(newPass, oldPass);
   console.log(result);
 })();
 ```


### PR DESCRIPTION
Fixed:
(oldPass, newPass) ==> (newPass, oldPass)